### PR TITLE
vagrant setup for testing the client against a redis cluster.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyc
 *.swp
 env27*
+vagrant/.vagrant
+

--- a/vagrant/.bash_profile
+++ b/vagrant/.bash_profile
@@ -1,0 +1,1 @@
+PATH=$PATH:/home/vagrant/redis/bin

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # ubuntu 64bit image
+  config.vm.box = "ubuntu-trusty"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vbguest.auto_update = true
+  
+  config.vm.provider :virtualbox do |vb|
+      #vb.gui = true
+      # hacky fix for trouble with ipv6 and dns network timeout
+      # https://github.com/mitchellh/vagrant/issues/1172
+      vb.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
+  end
+  
+  # map the root of project to our home folder
+  config.vm.synced_folder "../", "/home/vagrant/redis-py-cluster"
+
+  # install the redis server
+  config.vm.provision :shell, :path => "bootstrap.sh"
+  config.vm.provision :shell, :path => "build_redis.sh"
+  config.vm.provision :shell, :path => "install_redis.sh"
+  config.vm.provision :file, :source => ".bash_profile", :destination => "/home/vagrant/.bash_profile"
+
+
+  # setup forwarded ports
+  config.vm.network "forwarded_port", guest: 7000, host: 7000
+  config.vm.network "forwarded_port", guest: 7001, host: 7001
+  config.vm.network "forwarded_port", guest: 7002, host: 7002
+  config.vm.network "forwarded_port", guest: 7003, host: 7003
+  config.vm.network "forwarded_port", guest: 7004, host: 7004
+  config.vm.network "forwarded_port", guest: 7005, host: 7005
+end

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# need make to build redis
+sudo apt-get install -y make supervisor
+
+sudo gem install redis

--- a/vagrant/build_redis.sh
+++ b/vagrant/build_redis.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+source /home/vagrant/redis-py-cluster/vagrant/redis_vars.sh
+
+pushd /home/vagrant
+
+rm -rf $REDIS_SUPERVISOR_CONF
+supervisorctl update
+
+
+# create a clean directory for redis
+rm -rf $REDIS_DIR
+
+# download, unpack and build redis
+mkdir -p $REDIS_DOWNLOAD_DIR
+cd $REDIS_DOWNLOAD_DIR
+rm -f $REDIS_PACKAGE
+rm -rf $REDIS_BUILD_DIR
+wget https://github.com/antirez/redis/archive/$REDIS_PACKAGE
+tar zxvf $REDIS_PACKAGE
+cd $REDIS_BUILD_DIR
+make
+
+mkdir -p $REDIS_DIR
+mkdir -p $REDIS_DIR/bin
+cp src/redis-server $REDIS_DIR/bin
+cp src/redis-cli $REDIS_DIR/bin
+cp src/redis-trib.rb $REDIS_DIR/bin
+cp ./redis.conf $REDIS_DIR/redis.conf
+
+for port in $REDIS_PORTS
+do
+    mkdir -p $REDIS_DIR/$port
+done
+
+popd

--- a/vagrant/install_redis.sh
+++ b/vagrant/install_redis.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+source /home/vagrant/redis-py-cluster/vagrant/redis_vars.sh
+
+
+rm -rf $REDIS_SUPERVISOR_CONF
+supervisorctl update
+
+
+for port in $REDIS_PORTS
+do
+echo "======================================"
+echo "INSTALLING REDIS SERVER: $port        "
+echo "======================================"
+
+supervisor_conf=$(cat <<EOF
+[program:redis-$port]
+command = $REDIS_DIR/bin/redis-server $REDIS_DIR/redis.conf --port $port --dir $REDIS_DIR/$port --cluster-enabled yes
+autostart = true
+autorestart = true
+stdout_logfile = syslog
+stderr_logfile = syslog
+
+EOF
+)
+
+echo "$supervisor_conf" >> $REDIS_SUPERVISOR_CONF
+
+rm -rf "$REDIS_DIR/$port/nodes.conf"
+
+done
+
+supervisorctl update
+
+sleep 2
+
+echo "======================================"
+echo "INITIALIZING REDIS CLUSTER            "
+echo "======================================"
+
+
+redis_host_list=""
+
+for port in $REDIS_PORTS
+do
+    redis_host_list="$redis_host_list 127.0.0.1:$port "
+done
+
+yes "yes" | $REDIS_DIR/bin/redis-trib.rb create --replicas 1 $redis_host_list

--- a/vagrant/redis_vars.sh
+++ b/vagrant/redis_vars.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+VAGRANT_DIR=/home/vagrant/redis-py-cluster/vagrant
+REDIS_VERSION=3.0.0-beta7
+REDIS_DOWNLOAD_DIR=/home/vagrant/redis-downloads
+REDIS_PACKAGE=$REDIS_VERSION.tar.gz
+REDIS_BUILD_DIR=$REDIS_DOWNLOAD_DIR/redis-$REDIS_VERSION
+REDIS_DIR=/home/vagrant/redis
+REDIS_SUPERVISOR_CONF=/etc/supervisor/conf.d/redis.conf
+REDIS_PORTS=$(seq 7000 7005)


### PR DESCRIPTION
This will spin up an ubuntu vagrant vm and install the latest beta build of redis inside. It kicks off redis on ports 7000-7005 using supervisord and initializes a redis cluster for testing against.
