### PR TITLE
more accurate string representation of RedisCluster object

### DIFF
--- a/rediscluster/rediscluster.py
+++ b/rediscluster/rediscluster.py
@@ -70,6 +70,11 @@ class RedisCluster(StrictRedis):
         if init_slot_cache:
             self.initialize_slots_cache()
 
+    def __repr__(self):
+        servers = list(set(['%s:%s'%(info['host'], info['port']) for info in self.startup_nodes]) )
+        servers.sort()
+        return "%s<%s>" % (type(self).__name__, ','.join(servers))
+
     def get_redis_link_from_node(self, node_obj):
         return self.get_redis_link(node_obj["host"], node_obj["port"])
 

--- a/tests/test_cluster_obj.py
+++ b/tests/test_cluster_obj.py
@@ -2,6 +2,7 @@ from __future__ import with_statement
 from rediscluster import RedisCluster
 import pytest
 import redis
+import re
 from .conftest import _get_client, skip_if_server_version_lt
 from rediscluster.exceptions import RedisClusterException
 
@@ -11,6 +12,9 @@ pytestmark = skip_if_server_version_lt('2.9.0')
 
 class TestClusterObj(object):
 
+    def test_representation(self, r):
+        assert re.search('^RedisCluster<[0-9\.\:\,]+>$', str(r) )
+    
     def test_blocked_strict_redis_args(self):
         """
         Some arguments should explicitly be blocked because they will not work in a cluster setup


### PR DESCRIPTION
With the test cluster in vagrant, a string representation of the object now looks like:

```
RedisCluster<127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003,127.0.0.1:7004,127.0.0.1:7005>
```
