### PR TITLE
support deleting multiple keys in one call

### DIFF
--- a/rediscluster/rediscluster.py
+++ b/rediscluster/rediscluster.py
@@ -463,6 +463,19 @@ class RedisCluster(StrictRedis):
 
         return True
 
+    def delete(self, *names):
+        """
+        "Delete one or more keys specified by ``names``"
+
+        Cluster impl: Iterate all keys and send DELETE for each key.
+                      This will go a lot slower than a normal delete call in StrictRedis.
+                      This method is no longer atomic.
+        """
+        count = 0
+        for arg in names:
+            count += self.execute_command('DEL', arg)
+        return count
+
     def renamenx(self, src, dst):
         """
         Rename key ``src`` to ``dst`` if ``dst`` doesn't already exist

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -133,7 +133,6 @@ class TestRedisCommands(object):
         r['a'] = 'foo'
         assert r.delete('a') == 1
 
-    @pytest.mark.xfail(reason="need to break out the keys to the correct nodes")
     def test_delete_with_multiple_keys(self, r):
         r['a'] = 'foo'
         r['b'] = 'bar'


### PR DESCRIPTION
handle multi-key deletes similar to how we handle mget, at least for now. Later we can hash the keys to determine key slots, map them to connections, and pack the commands and issue them in parallel. This patch just gets us to a functional equivalent of redis-py.
