### PR TITLE
limited support for zinterstore and zunionstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ Pipelines do not work the same way in cluster mode. In 'StrictRedis' it batch al
 
 Alot of methods will behave very different when using RedisCluster. Some methods send the same request to all servers and return the result in another format then 'StrictRedis' do. Some methods is blocked because they do not work / is not implemented / is dangerous to use in cluster mode (like shutdown()).
 
+Some of the commands are only partially supported when using RedisCluster.  The commands ``zinterstore`` and ``zunionstore`` are only supported if all the keys map to the same key slot in the cluster. This can be achieved by namespacing related keys with a prefix followed by a bracketed common key. Example: 
+
+
+```
+r.zunionstore('d{foo}', ['a{foo}', 'b{foo}', 'c{foo}'])
+```
+
+This corresponds to how redis behaves in cluster mode. Eventually these commands will likely be more fully supported by implementing the logic in the client library at the expense of atomicity and performance.
 
 
 ## Usage example

--- a/rediscluster/rediscluster.py
+++ b/rediscluster/rediscluster.py
@@ -907,8 +907,6 @@ RedisCluster.script_load = block_command(StrictRedis.script_load)
 RedisCluster.register_script = block_command(StrictRedis.register_script)
 RedisCluster.move = block_command(StrictRedis.move)  # It is not possible to move a key from one db to another in cluster mode
 RedisCluster.bitop = block_command(StrictRedis.bitop)  # Currently to hard to implement a solution in python space
-RedisCluster.zinterstore = block_command(StrictRedis.zinterstore)  # TODO: Need impl
-RedisCluster.zunionstore = block_command(StrictRedis.zunionstore)  # TODO: Need impl
 
 # All commands that can be sent to any node in the cluster and dont care about key routing
 RedisCluster.publish = send_to_random_node(StrictRedis.publish)

--- a/tests/test_cluster_obj.py
+++ b/tests/test_cluster_obj.py
@@ -216,8 +216,6 @@ class TestClusterObj(object):
             "unwatch": r.unwatch,
             "move": r.move,
             "bitop": r.bitop,
-            "zinterstore": r.zinterstore,
-            "zunionstore": r.zunionstore,
         }
 
         for key, method in methods.items():


### PR DESCRIPTION
This is the last of my changes originally submitted in https://github.com/Grokzen/redis-py-cluster/pull/12.
All the others are now either merged in or queued up in their own patch request.
