### PR TITLE
exclude git directory when running pep8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,4 +40,4 @@ commands = py.test []
 
 [testenv:pep8]
 deps = pep8
-commands = pep8 --repeat --show-source --exclude=.venv,.tox,dist,docs,build,*.egg --ignore=E501 .
+commands = pep8 --repeat --show-source --exclude=.venv,.tox,dist,docs,build,*.egg,.git --ignore=E501 .


### PR DESCRIPTION
if you run pep8 with the -v flag you'll see it is scanning the hidden .git directory. Not a big deal, it doesn't find anything in there to try to validate, but we should probably exclude it.
