### PR TITLE
disable multi-step commands in pipeline context -v2

### DIFF
--- a/rediscluster/decorators.py
+++ b/rediscluster/decorators.py
@@ -130,3 +130,12 @@ def block_command(func):
     def inner(*args, **kwargs):
         raise RedisClusterException(" ERROR: Calling function {} is blocked when running redis in cluster mode...".format(func.__name__))
     return inner
+
+
+def block_pipeline_command(func):
+    """
+    Prints error because some pipelined commands should be blocked when running in cluster-mode
+    """
+    def inner(*args, **kwargs):
+        raise RedisClusterException(" ERROR: Calling pipelined function {} is blocked when running redis in cluster mode...".format(func.__name__))
+    return inner

--- a/rediscluster/rediscluster.py
+++ b/rediscluster/rediscluster.py
@@ -15,7 +15,8 @@ from .decorators import (send_to_connection_by_key,
                          get_connection_from_node_obj,
                          send_eval_to_connection,
                          send_to_random_node,
-                         block_command)
+                         block_command,
+                         block_pipeline_command)
 
 # 3rd party imports
 import redis
@@ -1001,7 +1002,35 @@ class BaseClusterPipeline(object):
     def script_load_for_pipeline(self, script):
         raise RedisClusterException("method script_load_for_pipeline() is not implemented")
 
+    def delete(self, *names):
+        """
+        "Delete a key specified by ``names``"
+        """
+        if len(names) != 1:
+            raise RedisClusterException("deleting multiple keys is not implemented in pipeline command")
+
+        return self.execute_command('DEL', names[0])
+
+
+# Blocked pipeline commands
+BaseClusterPipeline.mget = block_pipeline_command(StrictRedis.mget)
+BaseClusterPipeline.mset = block_pipeline_command(StrictRedis.mset)
+BaseClusterPipeline.msetnx = block_pipeline_command(StrictRedis.msetnx)
+BaseClusterPipeline.rename = block_pipeline_command(StrictRedis.rename)
+BaseClusterPipeline.renamenx = block_pipeline_command(StrictRedis.renamenx)
+BaseClusterPipeline.brpoplpush = block_pipeline_command(StrictRedis.brpoplpush)
+BaseClusterPipeline.rpoplpush = block_pipeline_command(StrictRedis.rpoplpush)
+BaseClusterPipeline.sort = block_pipeline_command(StrictRedis.sort)
+BaseClusterPipeline.sdiff = block_pipeline_command(StrictRedis.sdiff)
+BaseClusterPipeline.sdiffstore = block_pipeline_command(StrictRedis.sdiffstore)
+BaseClusterPipeline.sinter = block_pipeline_command(StrictRedis.sinter)
+BaseClusterPipeline.sinterstore = block_pipeline_command(StrictRedis.sinterstore)
+BaseClusterPipeline.smove = block_pipeline_command(StrictRedis.smove)
+BaseClusterPipeline.sunion = block_pipeline_command(StrictRedis.sunion)
+BaseClusterPipeline.sunionstore = block_pipeline_command(StrictRedis.sunionstore)
+BaseClusterPipeline.pfmerge = block_pipeline_command(StrictRedis.pfmerge)
+
 
 class StrictClusterPipeline(BaseClusterPipeline, RedisCluster):
-    "Pipeline for the StrictRedis class"
+    """Pipeline for the StrictRedis class"""
     pass

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,8 +1,8 @@
 from __future__ import with_statement
 import pytest
-
 import redis
 from redis._compat import b, u, unichr, unicode
+
 from rediscluster.exceptions import RedisClusterException
 
 
@@ -276,3 +276,91 @@ class TestPipeline(object):
             r.pipeline(shard_hint=True)
 
         assert unicode(ex.value).startswith("shard_hint is deprecated in cluster mode"), True
+
+    def test_mget_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.mget(['a'])
+
+    def test_mset_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.mset({'a': 1, 'b': 2})
+
+    def test_rename_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.rename('a', 'b')
+
+    def test_renamenx_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.renamenx('a', 'b')
+
+    def test_delete_single(self, r):
+        r['a'] = 1
+        with r.pipeline(transaction=False) as pipe:
+            pipe.delete('a')
+            assert pipe.execute(), True
+
+    def test_multi_delete_unsupported(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            r['a'] = 1
+            r['b'] = 2
+            with pytest.raises(RedisClusterException):
+                pipe.delete('a', 'b')
+
+    def test_brpoplpush_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.brpoplpush()
+
+    def test_rpoplpush_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.rpoplpush()
+
+    def test_sort_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.sort()
+
+    def test_sdiff_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.sdiff()
+
+    def test_sdiffstore_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.sdiffstore()
+
+    def test_sinter_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.sinter()
+
+    def test_sinterstore_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.sinterstore()
+
+    def test_smove_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.smove()
+
+    def test_sunion_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.sunion()
+
+    def test_sunionstore_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.sunionstore()
+
+    def test_spfmerge_disabled(self, r):
+        with r.pipeline(transaction=False) as pipe:
+            with pytest.raises(RedisClusterException):
+                pipe.pfmerge()


### PR DESCRIPTION
disabling certain commands in pipeline context until we can match the behavior of redis-py.

Renamed function to block_pipeline_command as requested.
