### PR TITLE
Fix "docts" typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ More detailed documentation can be found in `docs` folder.
 - [Setup a redis cluster. Manually, Docker & Vagrant](docs/Cluster_Setup.md)
 - [Command differences](docs/Commands.md)
 - [Limitations and differences](docs/Limits_and_differences.md)
-- [Redisco support (Django ORM)](docts/Redisco.md)
+- [Redisco support (Django ORM)](docs/Redisco.md)
 
 
 


### PR DESCRIPTION
- docts -> docs
