### PR TITLE
add redis cluster management commands: slots, info and nodes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
     * Renamed RedisCluster --> StrictRedisCluster
     * Implement backwards compatible redis.Redis class in cluster mode. It was named RedisCluster and everyone updating from 0.2.0 to 0.3.0 should consult docs/Upgrading.md for instructions how to change your code.
     * Added comprehensive documentation regarding pipelines
+    * Meta retrieval commands(slots, nodes, info) for Redis Cluster. (iandyh)
 
 * 0.2.0
     * Moved pipeline code into new file.

--- a/docs/Authors
+++ b/docs/Authors
@@ -17,3 +17,4 @@ Authors who contributed code or testing:
  - Dobrite - https://github.com/dobrite
  - 72squared - https://github.com/72squared
  - Neuron Teckid - https://github.com/neuront
+ - iandyh - https://github.com/iandyh

--- a/rediscluster/__init__.py
+++ b/rediscluster/__init__.py
@@ -5,6 +5,7 @@ import sys
 
 # Import shortcut
 from .client import StrictRedisCluster, RedisCluster
+from .cluster_mgt import RedisClusterMgt
 from .pipeline import StrictClusterPipeline
 from .pubsub import ClusterPubSub
 

--- a/rediscluster/__init__.py
+++ b/rediscluster/__init__.py
@@ -5,7 +5,7 @@ import sys
 
 # Import shortcut
 from .client import StrictRedisCluster, RedisCluster
-from .cluster_mgt import RedisClusterMgt
+from .cluster_mgt import RedisClusterMgt  # NOQA
 from .pipeline import StrictClusterPipeline
 from .pubsub import ClusterPubSub
 

--- a/rediscluster/cluster_mgt.py
+++ b/rediscluster/cluster_mgt.py
@@ -18,7 +18,7 @@ class RedisClusterMgt(object):
             startup_nodes=startup_nodes,
             init_slot_cache=True, **kwargs
         )
-        
+
     def __getattr__(self, attr):
         if attr in self.blocked_args:
             raise RedisClusterException('%s is currently not supported' % attr)
@@ -36,21 +36,21 @@ class RedisClusterMgt(object):
             finally:
                 self.connection_pool.release(c)
         return first_key(command, res)
-        
+
     def _execute_cluster_commands(self, *args, **kwargs):
         args = ('cluster',) + args
         node = self.connection_pool.nodes.random_node()
         return self._execute_command_on_nodes([node], *args, **kwargs)
 
     def info(self):
-        raw = self._execute_cluster_commands('info')        
+        raw = self._execute_cluster_commands('info')
         def _split(line):
             k, v = line.split(':')
             yield k
             yield v
         return {k: v for k, v in
                 [_split(line) for line in raw.split('\r\n') if line]}
-            
+
     def _make_host(self, host, port):
         return '%s:%s' % (host, port)
 
@@ -67,7 +67,7 @@ class RedisClusterMgt(object):
             for slave_ip, slave_port in slaves:
                 slave_host = nslookup(slave_ip) if host_required else slave_ip
                 slave_slots[self._make_host(slave_host, slave_port)].append(slots)
-        
+
         return {
             'master': master_slots,
             'slave': slave_slots
@@ -81,7 +81,7 @@ class RedisClusterMgt(object):
         return ret
 
     def nodes(self, host_required=False):
-        raw =  self._execute_cluster_commands('nodes')
+        raw = self._execute_cluster_commands('nodes')
         ret = {}
         for line in raw.split('\n'):
             if not line:

--- a/rediscluster/cluster_mgt.py
+++ b/rediscluster/cluster_mgt.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict
 
-from .client import StrictRedisCluster
 from .connection import ClusterConnectionPool
 from .exceptions import RedisClusterException
 from .utils import clusterdown_wrapper, first_key, nslookup

--- a/rediscluster/cluster_mgt.py
+++ b/rediscluster/cluster_mgt.py
@@ -14,10 +14,10 @@ class RedisClusterMgt(object):
                     'getkeysinslot', 'keyslot', 'meet', 'replicate', 'reset',
                     'saveconfig', 'set_config_epoch', 'setslot', 'slaves')
 
-    def __init__(self, startup_nodes):
+    def __init__(self, startup_nodes=None, **kwargs):
         self.connection_pool = ClusterConnectionPool(
             startup_nodes=startup_nodes,
-            init_slot_cache=True            
+            init_slot_cache=True, **kwargs
         )
         
     def __getattr__(self, attr):

--- a/rediscluster/cluster_mgt.py
+++ b/rediscluster/cluster_mgt.py
@@ -44,6 +44,7 @@ class RedisClusterMgt(object):
 
     def info(self):
         raw = self._execute_cluster_commands('info')
+
         def _split(line):
             k, v = line.split(':')
             yield k

--- a/rediscluster/cluster_mgt.py
+++ b/rediscluster/cluster_mgt.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
 
 from .client import StrictRedisCluster
 from .connection import ClusterConnectionPool
@@ -56,17 +57,17 @@ class RedisClusterMgt(object):
 
     def slots(self, host_required=False):
         slots_info = self._execute_cluster_commands('slots')
-        master_slots = {}
-        slave_slots = {}
+        master_slots = defaultdict(list)
+        slave_slots = defaultdict(list)
         for item in slots_info:
             master_ip, master_port = item[2]
             slots = [item[0], item[1]]
             master_host = nslookup(master_ip) if host_required else master_ip
-            master_slots[self._make_host(master_host, master_port)] = slots
+            master_slots[self._make_host(master_host, master_port)].append(slots)
             slaves = item[3:]
             for slave_ip, slave_port in slaves:
                 slave_host = nslookup(slave_ip) if host_required else slave_ip
-                slave_slots[self._make_host(slave_host, slave_port)] = slots
+                slave_slots[self._make_host(slave_host, slave_port)].append(slots)
         
         return {
             'master': master_slots,

--- a/rediscluster/cluster_mgt.py
+++ b/rediscluster/cluster_mgt.py
@@ -74,15 +74,12 @@ class RedisClusterMgt(object):
         }
 
     def _parse_node_line(self, line):
-        slots = None
-        if 'slave' in line:
-            (node_id, ip_port, flags, master_id, ping, pong, epoch,
-                status) = line.split(' ')
-        else:
-            (node_id, ip_port, flags, master_id, ping, pong, epoch,
-                status, slots) = line.split(' ')
-        return (node_id, ip_port, flags, master_id, ping, pong, epoch,
-                status, slots)
+        line_items = line.split(' ')
+        ret = line_items[:8]
+        slots = [sl.split('-') for sl in line_items[8:]]
+        ret.append(slots)
+        print ret
+        return ret
 
     def nodes(self, host_required=False):
         raw =  self._execute_cluster_commands('nodes')
@@ -105,6 +102,6 @@ class RedisClusterMgt(object):
                 'last_pong_rcvd': pong,
                 'epoch': epoch,
                 'status': status,
-                'slots': slots.split('-') if slots else ''
+                'slots': slots
             }
         return ret

--- a/rediscluster/cluster_mgt.py
+++ b/rediscluster/cluster_mgt.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+from .client import StrictRedisCluster
+from .connection import ClusterConnectionPool
+from .exceptions import RedisClusterException
+from .utils import clusterdown_wrapper, first_key, nslookup
+
+
+class RedisClusterMgt(object):
+
+    blocked_args = ('addslots', 'count_failure_reports',
+                    'countkeysinslot', 'delslots', 'failover', 'forget',
+                    'getkeysinslot', 'keyslot', 'meet', 'replicate', 'reset',
+                    'saveconfig', 'set_config_epoch', 'setslot', 'slaves')
+
+    def __init__(self, startup_nodes):
+        self.connection_pool = ClusterConnectionPool(
+            startup_nodes=startup_nodes,
+            init_slot_cache=True            
+        )
+        
+    def __getattr__(self, attr):
+        if attr in self.blocked_args:
+            raise RedisClusterException('%s is currently not supported' % attr)
+        raise RedisClusterException('%s is not a valid Redis cluster argument' % attr)
+
+    @clusterdown_wrapper
+    def _execute_command_on_nodes(self, nodes, *args, **kwargs):
+        command = args[0]
+        res = {}
+        for node in nodes:
+            c = self.connection_pool.get_connection_by_node(node)
+            try:
+                c.send_command(*args)
+                res[node["name"]] = c.read_response()
+            finally:
+                self.connection_pool.release(c)
+        return first_key(command, res)
+        
+    def _execute_cluster_commands(self, *args, **kwargs):
+        args = ('cluster',) + args
+        node = self.connection_pool.nodes.random_node()
+        return self._execute_command_on_nodes([node], *args, **kwargs)
+
+    def info(self):
+        raw = self._execute_cluster_commands('info')        
+        def _split(line):
+            k, v = line.split(':')
+            yield k
+            yield v
+        return {k: v for k, v in
+                [_split(line) for line in raw.split('\r\n') if line]}
+            
+    def _make_host(self, host, port):
+        return '%s:%s' % (host, port)
+
+    def slots(self, host_required=False):
+        slots_info = self._execute_cluster_commands('slots')
+        master_slots = dict()
+        slave_slots = dict()
+        for item in slots_info:
+            master_ip, master_port = item[2]
+            slots = [item[0], item[1]]
+            master_host = nslookup(master_ip) if host_required else master_ip
+            master_slots[self._make_host(master_host, master_port)] = slots
+            slaves = item[3:]
+            for slave_ip, slave_port in slaves:
+                slave_host = nslookup(slave_ip) if host_required else slave_ip
+                slave_slots[self._make_host(slave_host, slave_port)] = slots
+        
+        return {
+            'master': master_slots,
+            'slave': slave_slots
+        }
+
+    def _parse_node_line(self, line):
+        slots = None
+        if 'slave' in line:
+            (node_id, ip_port, flags, master_id, ping, pong, epoch,
+                status) = line.split(' ')
+        else:
+            (node_id, ip_port, flags, master_id, ping, pong, epoch,
+                status, slots) = line.split(' ')
+        return (node_id, ip_port, flags, master_id, ping, pong, epoch,
+                status, slots)
+
+    def nodes(self, host_required=False):
+        raw =  self._execute_cluster_commands('nodes')
+        ret = dict()
+        for line in raw.split('\n'):
+            if not line:
+                continue
+            node_id, ip_port, flags, master_id, ping, pong, epoch, \
+                status, slots = self._parse_node_line(line)
+            role = flags
+            if ',' in flags:
+                _, role = flags.split(',')
+
+            host = nslookup(ip_port) if host_required else ip_port
+            ret[host] = {
+                'node_id': node_id,
+                'role': role,
+                'master_id': master_id,
+                'last_ping_sent': ping,
+                'last_pong_rcvd': pong,
+                'epoch': epoch,
+                'status': status,
+                'slots': slots.split('-') if slots else ''
+            }
+        return ret

--- a/rediscluster/cluster_mgt.py
+++ b/rediscluster/cluster_mgt.py
@@ -56,8 +56,8 @@ class RedisClusterMgt(object):
 
     def slots(self, host_required=False):
         slots_info = self._execute_cluster_commands('slots')
-        master_slots = dict()
-        slave_slots = dict()
+        master_slots = {}
+        slave_slots = {}
         for item in slots_info:
             master_ip, master_port = item[2]
             slots = [item[0], item[1]]
@@ -78,12 +78,11 @@ class RedisClusterMgt(object):
         ret = line_items[:8]
         slots = [sl.split('-') for sl in line_items[8:]]
         ret.append(slots)
-        print ret
         return ret
 
     def nodes(self, host_required=False):
         raw =  self._execute_cluster_commands('nodes')
-        ret = dict()
+        ret = {}
         for line in raw.split('\n'):
             if not line:
                 continue

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -96,4 +96,3 @@ def nslookup(node_ip):
         return gethostbyaddr(node_ip)[0]
     ip, port = node_ip.split(':')
     return '%s:%s' % (gethostbyaddr(ip)[0], port)
-    

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from socket import gethostbyaddr
 
 # rediscluster imports
 from .exceptions import RedisClusterException, ClusterDownException
@@ -88,3 +89,11 @@ def clusterdown_wrapper(func):
         # If it fails 3 times then raise exception back to caller
         raise ClusterDownException("CLUSTERDOWN error. Unable to rebuild the cluster")
     return inner
+
+
+def nslookup(node_ip):
+    if ':' not in node_ip:
+        return gethostbyaddr(node_ip)[0]
+    ip, port = node_ip.split(':')
+    return '%s:%s' % (gethostbyaddr(ip)[0], port)
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,8 @@ def _init_client(request, cls=None, **kwargs):
     return client
 
 
-def _init_mgt_client(request, cls=None):
-    client = _get_client(cls=cls)
+def _init_mgt_client(request, cls=None, **kwargs):
+    client = _get_client(cls=cls, **kwargs)
     if request:
         def teardown():
             client.connection_pool.disconnect()
@@ -122,4 +122,5 @@ def rcm(request, *args, **kwargs):
     """
     Returns a instance of RedisClusterMgt
     """
-    return _init_mgt_client(request, cls=RedisClusterMgt, **kwargs)
+    return _init_mgt_client(request, cls=RedisClusterMgt, decode_responses=True,
+                            **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,17 +76,18 @@ def skip_if_redis_py_version_lt(min_version):
 @pytest.fixture()
 def o(request, **kwargs):
     """
-    Create a RedisCluster instance with decode_responses set to True.
+    Create a StrictRedisCluster instance with decode_responses set to True.
     """
-    return _init_client(request, decode_responses=True, **kwargs)
+    return _init_client(request, cls=StrictRedisCluster, decode_responses=True,
+                        **kwargs)
 
 
 @pytest.fixture()
 def r(request, **kwargs):
     """
-    Create a RedisCluster instance with default settings.
+    Create a StrictRedisCluster instance with default settings.
     """
-    return _init_client(request, **kwargs)
+    return _init_client(request, cls=StrictRedisCluster, **kwargs)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import sys
 import json
 
 # rediscluster imports
-from rediscluster import StrictRedisCluster, RedisCluster
+from rediscluster import StrictRedisCluster, RedisCluster, RedisClusterMgt
 
 # 3rd party imports
 import pytest
@@ -34,15 +34,24 @@ def _get_client(cls=None, **kwargs):
 
     params = {'startup_nodes': [{'host': '127.0.0.1', 'port': 7000}], 'socket_timeout': 10, 'decode_responses': False}
     params.update(kwargs)
-    return StrictRedisCluster(**params)
+    return cls(**params)
 
 
 def _init_client(request, cls=None, **kwargs):
-    client = _get_client(**kwargs)
+    client = _get_client(cls=cls, **kwargs)
     client.flushdb()
     if request:
         def teardown():
             client.flushdb()
+            client.connection_pool.disconnect()
+        request.addfinalizer(teardown)
+    return client
+
+
+def _init_mgt_client(request, cls=None):
+    client = _get_client(cls=cls)
+    if request:
+        def teardown():
             client.connection_pool.disconnect()
         request.addfinalizer(teardown)
     return client
@@ -105,3 +114,11 @@ def sr(request, *args, **kwargs):
     Returns a instance of StrictRedisCluster
     """
     return _init_client(request, cls=StrictRedisCluster, **kwargs)
+
+
+@pytest.fixture()
+def rcm(request, *args, **kwargs):
+    """
+    Returns a instance of RedisClusterMgt
+    """
+    return _init_mgt_client(request, cls=RedisClusterMgt, **kwargs)

--- a/tests/test_redis_cluster_mgt.py
+++ b/tests/test_redis_cluster_mgt.py
@@ -3,7 +3,7 @@
 class TestRedisClusterMgt(object):
 
     def test_info(self, rcm):
-        info = rcm.info()        
+        info = rcm.info()
         assert 'cluster_state' in info
 
     def test_slots(self, rcm):
@@ -12,11 +12,11 @@ class TestRedisClusterMgt(object):
         assert 'slave' in slots
 
         master_slots = slots['master']
-        for host, slots in master_slots.items():        
+        for host, slots in master_slots.items():
             s = slots[0]
             # node can have multiple slots
             # as a result, the format is [[1, 2], [3, 4]]
-            assert isinstance(s, list) 
+            assert isinstance(s, list)
             assert len(s) == 2
 
     def test_nodes(self, rcm):

--- a/tests/test_redis_cluster_mgt.py
+++ b/tests/test_redis_cluster_mgt.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+
 class TestRedisClusterMgt(object):
 
     def test_info(self, rcm):

--- a/tests/test_redis_cluster_mgt.py
+++ b/tests/test_redis_cluster_mgt.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+class TestRedisClusterMgt(object):
+
+    def test_info(self, rcm):
+        info = rcm.info()        
+        assert 'cluster_state' in info
+
+    def test_slots(self, rcm):
+        slots = rcm.slots()
+        assert 'master' in slots
+        assert 'slave' in slots
+
+        master_slots = slots['master']
+        for host, slots in master_slots.iteritems():        
+            s = slots[0]
+            # node can have multiple formats
+            # as a result, the format is [[1, 2], [3, 4]]
+            assert isinstance(s, list) 
+            assert len(s) == 2
+
+    def test_nodes(self, rcm):
+        nodes = rcm.nodes()
+        for host, info in nodes.iteritems():
+            assert 'role' in info
+            assert 'slots' in info

--- a/tests/test_redis_cluster_mgt.py
+++ b/tests/test_redis_cluster_mgt.py
@@ -12,7 +12,7 @@ class TestRedisClusterMgt(object):
         assert 'slave' in slots
 
         master_slots = slots['master']
-        for host, slots in master_slots.iteritems():        
+        for host, slots in master_slots.items():        
             s = slots[0]
             # node can have multiple slots
             # as a result, the format is [[1, 2], [3, 4]]
@@ -21,6 +21,6 @@ class TestRedisClusterMgt(object):
 
     def test_nodes(self, rcm):
         nodes = rcm.nodes()
-        for host, info in nodes.iteritems():
+        for host, info in nodes.items():
             assert 'role' in info
             assert 'slots' in info

--- a/tests/test_redis_cluster_mgt.py
+++ b/tests/test_redis_cluster_mgt.py
@@ -14,7 +14,7 @@ class TestRedisClusterMgt(object):
         master_slots = slots['master']
         for host, slots in master_slots.iteritems():        
             s = slots[0]
-            # node can have multiple formats
+            # node can have multiple slots
             # as a result, the format is [[1, 2], [3, 4]]
             assert isinstance(s, list) 
             assert len(s) == 2


### PR DESCRIPTION
A quick implementation.

The usage will be: `rcm = RedisClusterMgt(startup_nodes); rcm.info()`

There are some reasons behind the design: 

1. Since the class `RedisClusterMgt` will focus on cluster operation specific commands, it makes no sense to pass `cluster` command every time. Instead, directly calling `info` or `nodes` will be more concise. This does make newbies confusing because it is different from the official documentation. But they can grasp the concept quickly IMO.

2. Currently only three commands are implemented which are the ones related to meta data retrieval. The necessity of other types of commands is unknown since `redis-tri.rb` can do them well especially for complex commands like `addslots`

I am open for discussion. And if the current design is enough, I can work on some other commands and the tests.

Thanks!
