### PR TITLE
Implemented READONLY mode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+* 1.1.0
+    * Added READONLY mode support, scales reads using slave nodes.
+
 * 1.0.0
     * No change to anything just a bump to 1.0.0 because the lib is now considered stable/production ready.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ More detailed documentation can be found in `docs` folder.
 - [Pipelines](docs/Pipelines.md)
 - [Threaded Pipeline support](docs/Threads.md)
 - [Cluster Management class](docs/ClusterMgt.md)
+- [READONLY mode](docs/Readonly_mode.md)
 - [Authors](docs/Authors)
 
 

--- a/docs/Authors
+++ b/docs/Authors
@@ -18,3 +18,4 @@ Authors who contributed code or testing:
  - 72squared - https://github.com/72squared
  - Neuron Teckid - https://github.com/neuront
  - iandyh - https://github.com/iandyh
+ - mumumu - https://github.com/mumumu

--- a/docs/Readonly_mode.md
+++ b/docs/Readonly_mode.md
@@ -9,17 +9,32 @@ redis-py-cluster also implements this mode. You can access slave by passing `rea
 >>> startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 >>> rc = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True)
 >>> rc.set("foo16706", "bar")
+>>> rc.set("foo81", "foo")
 True
 >>> rc_readonly = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True, readonly_mode=True)
 >>> rc_readonly.get("foo16706")
 u'bar'
+>>> rc_readonly.get("foo81")
+u'foo'
+```
+
+We can use pipeline via `readonly_mode=True` object.
+
+```python
+>>> with rc_readonly.pipeline() as readonly_pipe:
+...     readonly_pipe.get('foo81')
+...     readonly_pipe.get('foo16706')
+...     readonly_pipe.execute()
+...
+[u'foo', u'bar']
 ```
 
 But this mode has some downside or limitations.
 
 - It is possible that you cannot get the latest data from READONLY mode enabled object because Redis implements asynchronous replication.
-- You MUST NOT use SET related operation with READONLY mode enabled object, otherwise you can possibly get 'Too many Cluster redirections' error because we choose master and its slave nodes randomly.
+- **You MUST NOT use SET related operation with READONLY mode enabled object**, otherwise you can possibly get 'Too many Cluster redirections' error because we choose master and its slave nodes randomly.
  - You should use get related stuff only.
+ - Ditto with pipeline, otherwise you can get 'Command # X (XXXX) of pipeline: MOVED' error.
 
 ```python
 >>> rc_readonly = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True, readonly_mode=True)

--- a/docs/Readonly_mode.md
+++ b/docs/Readonly_mode.md
@@ -1,0 +1,30 @@
+# READONLY mode
+
+By default, Redis Cluster always returns MOVE redirection response on accessing slave node. You can overcome this limitation [for scaling read with READONLY mode](http://redis.io/topics/cluster-spec#scaling-reads-using-slave-nodes).
+
+redis-py-cluster also implements this mode. You can access slave by passing `readonly_mode=True` to StrictRedisCluster (or RedisCluster) constructor.
+
+```python
+>>> from rediscluster import StrictRedisCluster
+>>> startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
+>>> rc = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True)
+>>> rc.set("foo16706", "bar")
+True
+>>> rc_readonly = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True, readonly_mode=True)
+>>> rc_readonly.get("foo16706")
+u'bar'
+```
+
+But this mode has some downside or limitations.
+
+- It is possible that you cannot get the latest data from READONLY mode enabled object because Redis implements asynchronous replication.
+- You MUST NOT use SET related operation with READONLY mode enabled object, otherwise you can possibly get 'Too many Cluster redirections' error because we choose master and its slave nodes randomly.
+ - You should use get related stuff only.
+
+```python
+>>> rc_readonly = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True, readonly_mode=True)
+>>> # NO: This works in almost case, but possibly emits Too many Cluster redirections error...
+>>> rc_readonly.set('foo', 'bar')
+>>> # OK: You should always use get related stuff...
+>>> rc_readonly.get('foo')
+```

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -287,7 +287,10 @@ class StrictRedisCluster(StrictRedis):
                 r = self.connection_pool.get_random_connection()
                 try_random_node = False
             else:
-                node = self.connection_pool.get_node_by_slot(slot)
+                if self.refresh_table_asap:  # MOVED
+                    node = self.connection_pool.get_master_node_by_slot(slot)
+                else:
+                    node = self.connection_pool.get_node_by_slot(slot)
                 r = self.connection_pool.get_connection_by_node(node)
 
             try:

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -7,7 +7,7 @@ import string
 import time
 
 # rediscluster imports
-from .connection import ClusterConnectionPool
+from .connection import ClusterConnectionPool, ClusterReadOnlyConnectionPool
 from .exceptions import RedisClusterException, ClusterDownException
 from .pubsub import ClusterPubSub
 from .utils import (
@@ -82,13 +82,14 @@ class StrictRedisCluster(StrictRedis):
     )
 
     def __init__(self, host=None, port=None, startup_nodes=None, max_connections=32, init_slot_cache=True,
-                 pipeline_use_threads=True, **kwargs):
+                 pipeline_use_threads=True, readonly_mode=False, **kwargs):
         """
         startup_nodes    --> List of nodes that initial bootstrapping can be done from
         host             --> Can be used to point to a startup node
         port             --> Can be used to point to a startup node
         max_connections  --> Maximum number of connections that should be kept open at one time
         pipeline_use_threads  ->  By default, use threads in pipeline if this flag is set to True
+        readonly_mode    --> enable READONLY mode. You can read possibly stale data from slave.
         **kwargs         --> Extra arguments that will be sent into StrictRedis instance when created
                              (See Official redis-py doc for supported kwargs
                              [https://github.com/andymccurdy/redis-py/blob/master/redis/client.py])
@@ -107,7 +108,8 @@ class StrictRedisCluster(StrictRedis):
         if host:
             startup_nodes.append({"host": host, "port": port if port else 7000})
 
-        self.connection_pool = ClusterConnectionPool(
+        connection_pool_cls = ClusterReadOnlyConnectionPool if readonly_mode else ClusterConnectionPool
+        self.connection_pool = connection_pool_cls(
             startup_nodes=startup_nodes,
             init_slot_cache=init_slot_cache,
             max_connections=max_connections,
@@ -157,7 +159,7 @@ class StrictRedisCluster(StrictRedis):
         if info['action'] == "MOVED":
             self.refresh_table_asap = True
             node = self.connection_pool.nodes.set_node(info['host'], info['port'], server_type='master')
-            self.connection_pool.nodes.slots[info['slot']] = node
+            self.connection_pool.nodes.slots[info['slot']][0] = node
         elif info['action'] == "ASK":
             node = self.connection_pool.nodes.set_node(info['host'], info['port'], server_type='master')
             return {'name': node['name'], 'method': 'ask'}

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -2,6 +2,7 @@
 
 # python std lib
 import os
+import random
 import threading
 from contextlib import contextmanager
 from itertools import chain
@@ -11,12 +12,27 @@ from .nodemanager import NodeManager
 from .exceptions import RedisClusterException
 
 # 3rd party imports
+from redis._compat import nativestr
 from redis.connection import ConnectionPool, Connection
+from redis.exceptions import ConnectionError
 
 
 class ClusterConnection(Connection):
     "Manages TCP communication to and from a Redis server"
     description_format = "ClusterConnection<host=%(host)s,port=%(port)s>"
+
+
+class ClusterReadOnlyConnection(Connection):
+    "Manages READONLY TCP communication to and from a Redis server"
+    description_format = "ClusterReadOnlyConnection<host=%(host)s,port=%(port)s>"
+
+    def on_connect(self):
+        "Initialize the connection, authenticate and select a database and send READONLY command"
+        super(ClusterReadOnlyConnection, self).on_connect()
+
+        self.send_command('READONLY')
+        if nativestr(self.read_response()) != 'OK':
+            raise ConnectionError('READONLY command failed')
 
 
 class UnixDomainSocketConnection(Connection):
@@ -198,7 +214,24 @@ class ClusterConnectionPool(ConnectionPool):
         return connection
 
     def get_node_by_slot(self, slot):
-        return self.nodes.slots[slot]
+        return self.nodes.slots[slot][0]
+
+
+class ClusterReadOnlyConnectionPool(ClusterConnectionPool):
+    """
+    Readonly connection pool for rediscluster
+    """
+
+    def __init__(self, startup_nodes=None, init_slot_cache=True, connection_class=ClusterReadOnlyConnection, max_connections=None, **connection_kwargs):
+        super(ClusterReadOnlyConnectionPool, self).__init__(
+            startup_nodes=startup_nodes,
+            init_slot_cache=init_slot_cache,
+            connection_class=connection_class,
+            max_connections=max_connections,
+            **connection_kwargs)
+
+    def get_node_by_slot(self, slot):
+        return random.choice(self.nodes.slots[slot])
 
 
 @contextmanager

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -213,8 +213,11 @@ class ClusterConnectionPool(ConnectionPool):
 
         return connection
 
-    def get_node_by_slot(self, slot):
+    def get_master_node_by_slot(self, slot):
         return self.nodes.slots[slot][0]
+
+    def get_node_by_slot(self, slot):
+        return self.get_master_node_by_slot(slot)
 
 
 class ClusterReadOnlyConnectionPool(ClusterConnectionPool):

--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -140,7 +140,7 @@ class StrictClusterPipeline(StrictRedisCluster):
                 if slot in ask_slots:
                     node = ask_slots[slot]
                 else:
-                    node = self.connection_pool.nodes.slots[slot]
+                    node = self.connection_pool.nodes.slots[slot][0]
 
                 self.connection_pool.nodes.set_node_name(node)
                 node_name = node['name']
@@ -211,7 +211,7 @@ class StrictClusterPipeline(StrictRedisCluster):
                 if redir['action'] == "MOVED":
                     self.refresh_table_asap = True
                     node = self.connection_pool.nodes.set_node(redir['host'], redir['port'], server_type='master')
-                    self.connection_pool.nodes.slots[redir['slot']] = node
+                    self.connection_pool.nodes.slots[redir['slot']][0] = node
                     attempt.append(i)
                     self._fail_on_redirect(allow_redirections)
                 elif redir['action'] == "ASK":

--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -140,7 +140,10 @@ class StrictClusterPipeline(StrictRedisCluster):
                 if slot in ask_slots:
                     node = ask_slots[slot]
                 else:
-                    node = self.connection_pool.nodes.slots[slot][0]
+                    if self.refresh_table_asap:  # MOVED
+                        node = self.connection_pool.get_master_node_by_slot(slot)
+                    else:
+                        node = self.connection_pool.get_node_by_slot(slot)
 
                 self.connection_pool.nodes.set_node_name(node)
                 node_name = node['name']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,16 @@ def r(request, **kwargs):
 
 
 @pytest.fixture()
+def ro(request, **kwargs):
+    """
+    Create a StrictRedisCluster instance with readonly mode
+    """
+    params = {'readonly_mode': True}
+    params.update(kwargs)
+    return _init_client(request, cls=StrictRedisCluster, **params)
+
+
+@pytest.fixture()
 def s(request, **kwargs):
     """
     Create a StrictRedisCluster instance with 'init_slot_cache' set to false

--- a/tests/test_cluster_connection_pool.py
+++ b/tests/test_cluster_connection_pool.py
@@ -123,6 +123,13 @@ class TestConnectionPool(object):
             pool.get_connection("GET")
         assert unicode(ex.value).startswith("Only 'pubsub' commands can be used by get_connection()")
 
+    def test_master_node_by_slot(self):
+        pool = self.get_pool(connection_kwargs={})
+        node = pool.get_master_node_by_slot(0)
+        node['port'] = 7000
+        node = pool.get_master_node_by_slot(12182)
+        node['port'] = 7002
+
 
 class TestReadOnlyConnectionPool(object):
     def get_pool(self, connection_kwargs=None, max_connections=None):

--- a/tests/test_cluster_connection_pool.py
+++ b/tests/test_cluster_connection_pool.py
@@ -8,7 +8,9 @@ import time
 from threading import Thread
 
 # rediscluster imports
-from rediscluster.connection import ClusterConnectionPool, ClusterConnection, UnixDomainSocketConnection
+from rediscluster.connection import (
+    ClusterConnectionPool, ClusterReadOnlyConnectionPool,
+    ClusterConnection, UnixDomainSocketConnection)
 from rediscluster.exceptions import RedisClusterException
 from tests.conftest import skip_if_server_version_lt
 
@@ -120,6 +122,42 @@ class TestConnectionPool(object):
         with pytest.raises(RedisClusterException) as ex:
             pool.get_connection("GET")
         assert unicode(ex.value).startswith("Only 'pubsub' commands can be used by get_connection()")
+
+
+class TestReadOnlyConnectionPool(object):
+    def get_pool(self, connection_kwargs=None, max_connections=None):
+        connection_kwargs = connection_kwargs or {}
+        pool = ClusterReadOnlyConnectionPool(
+            max_connections=max_connections,
+            startup_nodes=[{"host": "127.0.0.1", "port": 7000}],
+            **connection_kwargs)
+        return pool
+
+    def test_repr_contains_db_info_readonly(self):
+        connection_kwargs = {'host': 'localhost', 'port': 7000}
+        pool = self.get_pool(connection_kwargs=connection_kwargs)
+        expected = 'ClusterReadOnlyConnectionPool<ClusterReadOnlyConnection<host=localhost,port=7000>>'
+        assert repr(pool) == expected
+
+    def test_max_connections(self):
+        pool = self.get_pool(max_connections=2)
+        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
+        with pytest.raises(RedisClusterException):
+            pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+
+    def test_get_node_by_slot(self):
+        """
+        We can randomly get all nodes in readonly mode.
+        """
+        pool = self.get_pool(connection_kwargs={})
+
+        expected_ports = {7000, 7003}
+        actual_ports = set()
+        for _ in range(0, 100):
+            node = pool.get_node_by_slot(0)
+            actual_ports.add(node['port'])
+        assert actual_ports == expected_ports
 
 
 class TestBlockingConnectionPool(object):

--- a/tests/test_cluster_obj.py
+++ b/tests/test_cluster_obj.py
@@ -6,7 +6,7 @@ import re
 
 # rediscluster imports
 from rediscluster import StrictRedisCluster
-from rediscluster.connection import ClusterConnectionPool
+from rediscluster.connection import ClusterConnectionPool, ClusterReadOnlyConnectionPool
 from rediscluster.exceptions import RedisClusterException
 from rediscluster.nodemanager import NodeManager
 from tests.conftest import _get_client, skip_if_server_version_lt
@@ -14,7 +14,7 @@ from tests.conftest import _get_client, skip_if_server_version_lt
 # 3rd party imports
 from mock import patch, Mock
 from redis.exceptions import ResponseError
-from redis._compat import unicode
+from redis._compat import b, unicode
 import pytest
 
 
@@ -56,6 +56,13 @@ def test_empty_startup_nodes(s):
         _get_client(init_slot_cache=False, startup_nodes=[])
 
     assert unicode(ex.value).startswith("No startup nodes provided"), unicode(ex.value)
+
+
+def test_readonly_instance(ro):
+    """
+    Test that readonly_mode=True instance has ClusterReadOnlyConnectionPool
+    """
+    assert isinstance(ro.connection_pool, ClusterReadOnlyConnectionPool)
 
 
 def test_blocked_commands(r):
@@ -115,12 +122,12 @@ def test_cluster_of_one_instance():
                 self.slots = {}
 
                 for i in range(0, 16383):
-                    self.slots[i] = {
+                    self.slots[i] = [{
                         'host': '127.0.0.1',
                         'server_type': 'master',
                         'port': 7006,
                         'name': '127.0.0.1:7006',
-                    }
+                    }]
 
                 # Second call should map all to 7007
                 def map_7007(self):
@@ -128,12 +135,12 @@ def test_cluster_of_one_instance():
                     self.slots = {}
 
                     for i in range(0, 16383):
-                        self.slots[i] = {
+                        self.slots[i] = [{
                             'host': '127.0.0.1',
                             'server_type': 'master',
                             'port': 7007,
                             'name': '127.0.0.1:7007',
-                        }
+                        }]
 
                 # First call should map all to 7006
                 init_mock.side_effect = map_7007
@@ -165,7 +172,7 @@ def test_moved_exception_handling(r):
     resp.message = "MOVED 1337 127.0.0.1:7000"
     r.handle_cluster_command_exception(resp)
     assert r.refresh_table_asap is True
-    assert r.connection_pool.nodes.slots[1337] == {
+    assert r.connection_pool.nodes.slots[1337][0] == {
         "host": "127.0.0.1",
         "port": 7000,
         "name": "127.0.0.1:7000",
@@ -240,12 +247,12 @@ def test_refresh_table_asap():
         mock_initialize.return_value = None
 
         r = StrictRedisCluster(host="127.0.0.1", port=7000)
-        r.connection_pool.nodes.slots[12182] = {
+        r.connection_pool.nodes.slots[12182] = [{
             "host": "127.0.0.1",
             "port": 7002,
             "name": "127.0.0.1:7002",
             "server_type": "master",
-        }
+        }]
         r.refresh_table_asap = True
 
         i = len(mock_initialize.mock_calls)
@@ -375,3 +382,46 @@ def test_moved_redirection_pipeline():
     p.parse_response = m
     p.set("foo", "bar")
     assert p.execute() == ["MOCK_OK"]
+
+
+def test_moved_redirection_on_slave_with_default_client():
+    """
+    Test that the client returns 'Too many Cluster redirections error'
+    with default (readonly_mode=False) client when we connect always to slave.
+    """
+
+    with patch.object(ClusterConnectionPool, 'get_node_by_slot') as return_slave_mock:
+        return_slave_mock.return_value = {
+            'name': '127.0.0.1:7004',
+            'host': '127.0.0.1',
+            'port': 7004,
+            'server_type': 'slave',
+        }
+
+        normal_client = StrictRedisCluster(host="127.0.0.1", port=7000)
+        with pytest.raises(RedisClusterException) as ex:
+            normal_client.get('foo')
+        assert unicode(ex.value).startswith('Too many Cluster redirections')
+
+
+def test_moved_redirection_on_slave_with_readonly_mode_client(sr):
+    """
+    Test that the client can get value normally with readonly mode
+    when we connect always to slave.
+    """
+
+    # we assume this key is set on 127.0.0.1:7001
+    sr.set('foo16706', 'foo')
+    import time
+    time.sleep(1)
+
+    with patch.object(ClusterConnectionPool, 'get_node_by_slot') as return_slave_mock:
+        return_slave_mock.return_value = {
+            'name': '127.0.0.1:7004',
+            'host': '127.0.0.1',
+            'port': 7004,
+            'server_type': 'slave',
+        }
+
+        readonly_client = StrictRedisCluster(host="127.0.0.1", port=7000, readonly_mode=True)
+        assert b('foo') == readonly_client.get('foo16706')

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,10 +5,13 @@ from __future__ import with_statement
 import re
 
 # rediscluster imports
+from rediscluster.client import StrictRedisCluster
+from rediscluster.connection import ClusterConnectionPool, ClusterReadOnlyConnectionPool
 from rediscluster.exceptions import RedisClusterException
 
 # 3rd party imports
 import pytest
+from mock import patch
 from redis._compat import b, u, unichr, unicode
 from redis.exceptions import WatchError, ResponseError, ConnectionError
 
@@ -469,3 +472,89 @@ class TestPipeline(object):
         p = r.pipeline()
         result = p.execute()
         assert result == []
+
+
+class TestReadOnlyPipeline(object):
+
+    def test_pipeline_readonly(self, r, ro):
+        """
+        On readonly mode, we supports get related stuff only.
+        """
+        r.set('foo71', 'a1')   # we assume this key is set on 127.0.0.1:7001
+        r.zadd('foo88', z1=1)  # we assume this key is set on 127.0.0.1:7002
+        r.zadd('foo88', z2=4)
+
+        with ro.pipeline() as readonly_pipe:
+            readonly_pipe.get('foo71').zrange('foo88', 0, 5, withscores=True)
+            assert readonly_pipe.execute() == [
+                b('a1'),
+                [(b('z1'), 1.0), (b('z2'), 4)],
+            ]
+
+    def assert_moved_redirection_on_slave(self, connection_pool_cls, cluster_obj):
+        with patch.object(connection_pool_cls, 'get_node_by_slot') as return_slave_mock:
+            with patch.object(ClusterConnectionPool, 'get_master_node_by_slot') as return_master_mock:
+                def get_mock_node(role, port):
+                    return {
+                        'name': '127.0.0.1:%d' % port,
+                        'host': '127.0.0.1',
+                        'port': port,
+                        'server_type': role,
+                    }
+
+                return_slave_mock.return_value = get_mock_node('slave', 7005)
+                return_master_mock.return_value = get_mock_node('slave', 7001)
+
+                with cluster_obj.pipeline() as pipe:
+                    # we assume this key is set on 127.0.0.1:7001(7004)
+                    pipe.get('foo87').get('foo88').execute() == [None, None]
+                    assert return_master_mock.call_count == 2
+
+    def test_moved_redirection_on_slave_with_default(self):
+        """
+        On Pipeline, we redirected once and finally get from master with
+        readonly client when data is completely moved.
+        """
+        self.assert_moved_redirection_on_slave(
+            ClusterConnectionPool,
+            StrictRedisCluster(host="127.0.0.1", port=7000)
+        )
+
+    def test_moved_redirection_on_slave_with_readonly_mode_client(self, sr):
+        """
+        Ditto with READONLY mode.
+        """
+        self.assert_moved_redirection_on_slave(
+            ClusterReadOnlyConnectionPool,
+            StrictRedisCluster(host="127.0.0.1", port=7000, readonly_mode=True)
+        )
+
+    def test_access_correct_slave_with_readonly_mode_client(self, sr):
+        """
+        Test that the client can get value normally with readonly mode
+        when we connect to correct slave.
+        """
+
+        # we assume this key is set on 127.0.0.1:7001
+        sr.set('foo87', 'foo')
+        sr.set('foo88', 'bar')
+        import time
+        time.sleep(1)
+
+        with patch.object(ClusterReadOnlyConnectionPool, 'get_node_by_slot') as return_slave_mock:
+            return_slave_mock.return_value = {
+                'name': '127.0.0.1:7004',
+                'host': '127.0.0.1',
+                'port': 7004,
+                'server_type': 'slave',
+            }
+
+            master_value = {'host': '127.0.0.1', 'name': '127.0.0.1:7001', 'port': 7001, 'server_type': 'master'}
+            with patch.object(
+                    ClusterConnectionPool,
+                    'get_master_node_by_slot',
+                    return_value=master_value) as return_master_mock:
+                readonly_client = StrictRedisCluster(host="127.0.0.1", port=7000, readonly_mode=True)
+                with readonly_client.pipeline() as readonly_pipe:
+                    assert readonly_pipe.get('foo88').get('foo87').execute() == [b('bar'), b('foo')]
+                    assert return_master_mock.call_count == 0


### PR DESCRIPTION
By default, Redis Cluster always returns MOVE redirection response on accessing slave node. To overcome this limitation for scaling read, I implemented [READONLY mode](http://redis.io/topics/cluster-spec#scaling-reads-using-slave-nodes) and its releated tests.

Please refer to docs/Readonly_mode.md for details.