### PR TITLE
Add max_connections_per_node on ClusterConnectionPool

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
     * Refactored exception handling and exception classes. 
     * Added READONLY mode support, scales reads using slave nodes.
     * Fix __repr__ for ClusterConnectionPool and ClusterReadOnlyConnectionPool
+    * Add max_connections_per_node parameter to ClusterConnectionPool so that max_connections parameter is calculated per-node rather than across the whole cluster.
 
 * 1.0.0
     * No change to anything just a bump to 1.0.0 because the lib is now considered stable/production ready.

--- a/docs/Authors
+++ b/docs/Authors
@@ -19,3 +19,4 @@ Authors who contributed code or testing:
  - Neuron Teckid - https://github.com/neuront
  - iandyh - https://github.com/iandyh
  - mumumu - https://github.com/mumumu
+ - awestendorf - https://github.com/awestendorf

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -19,6 +19,8 @@ Added new `MovedError` exception class.
 
 Added new `ClusterCrossSlotError` exception class.
 
+Added optional `max_connections_per_node` parameter to `ClusterConnectionPool` which changes behavior of `max_connections` so that it applies per-node rather than across the whole cluster. The new feature is opt-in, and the existing default behavior is unchanged. Users are recommended to opt-in as the feature fixes two important problems. First is that some nodes could be starved for connections after max_connections is used up by connecting to other nodes. Second is that the asymmetric number of connections across nodes makes it challenging to configure file descriptor and redis max client settings.
+
 
 
 ## 0.2.0 --> 0.3.0

--- a/tests/test_cluster_connection_pool.py
+++ b/tests/test_cluster_connection_pool.py
@@ -33,11 +33,12 @@ class DummyConnection(object):
 
 
 class TestConnectionPool(object):
-    def get_pool(self, connection_kwargs=None, max_connections=None, connection_class=DummyConnection, init_slot_cache=True):
+    def get_pool(self, connection_kwargs=None, max_connections=None, max_connections_per_node=None, connection_class=DummyConnection, init_slot_cache=True):
         connection_kwargs = connection_kwargs or {}
         pool = ClusterConnectionPool(
             connection_class=connection_class,
             max_connections=max_connections,
+            max_connections_per_node=max_connections_per_node,
             startup_nodes=[{"host": "127.0.0.1", "port": 7000}],
             init_slot_cache=init_slot_cache,
             **connection_kwargs)
@@ -58,6 +59,15 @@ class TestConnectionPool(object):
 
     def test_max_connections(self):
         pool = self.get_pool(max_connections=2)
+        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
+        with pytest.raises(RedisClusterException):
+            pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+
+    def test_max_connections_per_node(self):
+        pool = self.get_pool(max_connections=2, max_connections_per_node=True)
+        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
         pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
         pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
         with pytest.raises(RedisClusterException):


### PR DESCRIPTION
This handles a situation where the max_connections argument applies to the whole cluster, and can starve connections on concurrent processes to nodes in the cluster. It also results in asymmetrical connection allocation across the nodes, which makes it challenging to configure file descriptor and redis max client settings.

The cluster-wide setting can also cause problems if the number of nodes is greater than max_connections.