### PR TITLE
Improve threadsafty when doing node discovery

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@
     * Improve thread safty of get_connection_by_slot and get_connection_by_node methods (iandyh)
     * Improved error handling when sending commands to all nodes, e.g. info. Now the connection takes retry_on_timeout as an option and retry once when there is a timeout. (iandyh)
     * Added support for SCRIPT LOAD, SCRIPT FLUSH, SCRIPT EXISTS and EVALSHA commands. (alisaifee)
+    * Improve thread safty to avoid exceptions when running one client object inside multiple threads and doing resharding of the
+      cluster at the same time.
 
 * 1.0.0
     * No change to anything just a bump to 1.0.0 because the lib is now considered stable/production ready.

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -21,6 +21,9 @@ Added new `ClusterCrossSlotError` exception class.
 
 Added optional `max_connections_per_node` parameter to `ClusterConnectionPool` which changes behavior of `max_connections` so that it applies per-node rather than across the whole cluster. The new feature is opt-in, and the existing default behavior is unchanged. Users are recommended to opt-in as the feature fixes two important problems. First is that some nodes could be starved for connections after max_connections is used up by connecting to other nodes. Second is that the asymmetric number of connections across nodes makes it challenging to configure file descriptor and redis max client settings.
 
+Reinitialize on `MOVED` errors will not run on every error but instead on every
+25 error to avoid excessive cluster reinitialize when used in multiple threads and resharding at the same time. If you want to go back to the old behaviour with reinitialize on every error you should pass in `reinitialize_steps=1` to the client constructor. If you want to increase or decrease the intervall of this new behaviour you should set `reinitialize_steps` in the client constructor to a value that you want.
+
 
 
 ## 0.2.0 --> 0.3.0

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -96,7 +96,7 @@ class StrictRedisCluster(StrictRedis):
     )
 
     def __init__(self, host=None, port=None, startup_nodes=None, max_connections=32, init_slot_cache=True,
-                 pipeline_use_threads=True, readonly_mode=False, **kwargs):
+                 pipeline_use_threads=True, readonly_mode=False, reinitialize_steps=None, **kwargs):
         """
         startup_nodes    --> List of nodes that initial bootstrapping can be done from
         host             --> Can be used to point to a startup node
@@ -136,6 +136,8 @@ class StrictRedisCluster(StrictRedis):
         self.result_callbacks = self.__class__.RESULT_CALLBACKS.copy()
         self.response_callbacks = self.__class__.RESPONSE_CALLBACKS.copy()
         self.pipeline_use_threads = pipeline_use_threads
+        self.reinitialize_counter = 0
+        self.reinitialize_steps = reinitialize_steps or 25
 
     def __repr__(self):
         servers = list(set(['{}:{}'.format(nativestr(info['host']), info['port']) for info in self.connection_pool.nodes.startup_nodes]))
@@ -263,7 +265,14 @@ class StrictRedisCluster(StrictRedis):
                 self.refresh_table_asap = True
                 raise e
             except MovedError as e:
-                self.refresh_table_asap = True
+                # Reinitialize on ever x number of MovedError.
+                # This counter will increase faster when the same client object
+                # is shared between multiple threads. To reduce the frequency you
+                # can set the variable 'reinitialize_steps' in the constructor.
+                self.reinitialize_counter += 1
+                if self.reinitialize_counter % self.reinitialize_steps == 0:
+                    self.refresh_table_asap = True
+
                 node = self.connection_pool.nodes.set_node(e.host, e.port, server_type='master')
                 self.connection_pool.nodes.slots[e.slot_id][0] = node
                 redirect_addr = "%s:%s" % (e.host, e.port)

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -167,7 +167,8 @@ class StrictRedisCluster(StrictRedis):
             nodes_callbacks=self.nodes_callbacks,
             result_callbacks=self.result_callbacks,
             response_callbacks=self.response_callbacks,
-            use_threads=self.pipeline_use_threads if use_threads is None else use_threads
+            use_threads=self.pipeline_use_threads if use_threads is None else use_threads,
+            reinitialize_steps=self.reinitialize_steps,
         )
 
     def transaction(self, func, *watches, **kwargs):

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -221,18 +221,4 @@ class NodeManager(object):
         """
         Drop all node data and start over from startup_nodes
         """
-        self.flush_nodes_cache()
-        self.flush_slots_cache()
         self.initialize()
-
-    def flush_slots_cache(self):
-        """
-        Reset slots cache back to empty dict
-        """
-        self.slots = {}
-
-    def flush_nodes_cache(self):
-        """
-        Reset nodes cache back to empty dict
-        """
-        self.nodes = {}

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -76,24 +76,6 @@ class NodeManager(object):
          and it could execute CLUSTER SLOTS command.
         """
         nodes_cache = {}
-
-        def _set_node(host, port, server_type=None):
-            """
-            TODO: Temporary location for this method
-
-            Update data for a node.
-            """
-            node_name = "{0}:{1}".format(host, port)
-            nodes_cache.setdefault(node_name, {})
-            nodes_cache[node_name]['host'] = host
-            nodes_cache[node_name]['port'] = port
-            nodes_cache[node_name]['name'] = node_name
-
-            if server_type:
-                nodes_cache[node_name]['server_type'] = server_type
-
-            return nodes_cache[node_name]
-
         tmp_slots = {}
 
         all_slots_covered = False
@@ -125,14 +107,17 @@ class NodeManager(object):
                     master_node[0] = node['host']
                 master_node[1] = int(master_node[1])
 
-                node = _set_node(master_node[0], master_node[1], server_type='master')
+                node, node_name = self.make_node_obj(master_node[0], master_node[1], 'master')
+                nodes_cache[node_name] = node
 
                 for i in range(int(slot[0]), int(slot[1]) + 1):
                     if i not in tmp_slots:
                         tmp_slots[i] = [node]
                         slave_nodes = [slot[j] for j in range(3, len(slot))]
+
                         for slave_node in slave_nodes:
-                            target_slave_node = _set_node(slave_node[0], slave_node[1], server_type='slave')
+                            target_slave_node, slave_node_name = self.make_node_obj(slave_node[0], slave_node[1], 'slave')
+                            nodes_cache[slave_node_name] = target_slave_node
                             tmp_slots[i].append(target_slave_node)
                     else:
                         # Validate that 2 nodes want to use the same slot cache setup
@@ -193,20 +178,30 @@ class NodeManager(object):
         if "name" not in n:
             n["name"] = "{0}:{1}".format(n["host"], n["port"])
 
+    def make_node_obj(self, host, port, server_type):
+        """
+        Create a node datastructure.
+
+        Returns the node datastructure and the node name
+        """
+        node_name = "{0}:{1}".format(host, port)
+        node = {
+            'host': host,
+            'port': port,
+            'name': node_name,
+            'server_type': server_type
+        }
+
+        return (node, node_name)
+
     def set_node(self, host, port, server_type=None):
         """
         Update data for a node.
         """
-        node_name = "{0}:{1}".format(host, port)
-        self.nodes.setdefault(node_name, {})
-        self.nodes[node_name]['host'] = host
-        self.nodes[node_name]['port'] = port
-        self.nodes[node_name]['name'] = node_name
+        node, node_name = self.make_node_obj(host, port, server_type)
+        self.nodes[node_name] = node
 
-        if server_type:
-            self.nodes[node_name]['server_type'] = server_type
-
-        return self.nodes[node_name]
+        return node
 
     def populate_startup_nodes(self):
         """

--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -207,7 +207,6 @@ class StrictClusterPipeline(StrictRedisCluster):
                     raise v
 
                 if isinstance(v, MovedError):
-                    self.refresh_table_asap = True
                     node = self.connection_pool.nodes.set_node(v.host, v.port, server_type='master')
                     self.connection_pool.nodes.slots[v.slot_id][0] = node
                     attempt.append(i)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ def sr(request, *args, **kwargs):
     """
     Returns a instance of StrictRedisCluster
     """
-    return _init_client(request, cls=StrictRedisCluster, **kwargs)
+    return _init_client(request, reinitialize_steps=1, cls=StrictRedisCluster, **kwargs)
 
 
 @pytest.fixture()

--- a/tests/test_node_manager.py
+++ b/tests/test_node_manager.py
@@ -118,22 +118,6 @@ def test_wrong_startup_nodes_type():
         NodeManager({})
 
 
-def test_flush_slots_nodes_cache():
-    """
-    Slots cache should already be populated.
-    """
-    n = NodeManager([{"host": "127.0.0.1", "port": 7000}])
-    n.initialize()
-    assert len(n.slots) == NodeManager.RedisClusterHashSlots
-    assert len(n.nodes) == 6
-
-    n.flush_slots_cache()
-    n.flush_nodes_cache()
-
-    assert len(n.slots) == 0
-    assert len(n.nodes) == 0
-
-
 def test_init_slots_cache_slots_collision():
     """
     Test that if 2 nodes do not agree on the same slots setup it should raise an error.

--- a/tests/test_node_manager.py
+++ b/tests/test_node_manager.py
@@ -270,12 +270,8 @@ def test_reset():
     """
     n = NodeManager(startup_nodes=[{}])
     n.initialize = Mock()
-    n.slots = {"foo": "bar"}
-    n.nodes = ["foo", "bar"]
     n.reset()
-
-    assert n.slots == {}
-    assert n.nodes == {}
+    assert n.initialize.call_count == 1
 
 
 def test_cluster_one_instance():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -517,7 +517,7 @@ class TestReadOnlyPipeline(object):
         """
         self.assert_moved_redirection_on_slave(
             ClusterConnectionPool,
-            StrictRedisCluster(host="127.0.0.1", port=7000)
+            StrictRedisCluster(host="127.0.0.1", port=7000, reinitialize_steps=1)
         )
 
     def test_moved_redirection_on_slave_with_readonly_mode_client(self, sr):
@@ -526,7 +526,7 @@ class TestReadOnlyPipeline(object):
         """
         self.assert_moved_redirection_on_slave(
             ClusterReadOnlyConnectionPool,
-            StrictRedisCluster(host="127.0.0.1", port=7000, readonly_mode=True)
+            StrictRedisCluster(host="127.0.0.1", port=7000, readonly_mode=True, reinitialize_steps=1)
         )
 
     def test_access_correct_slave_with_readonly_mode_client(self, sr):


### PR DESCRIPTION
This PR will fix the reported issue that when used inside threads the code explodes when `nodemanager.initialize` is runned during a reshard operation.

The work is still a WIP and not ready to be merged.