### PR TITLE
Enable SCRIPT commands LOAD/FLUSH/EXISTS/EVALSHA

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
     * Add max_connections_per_node parameter to ClusterConnectionPool so that max_connections parameter is calculated per-node rather than across the whole cluster.
     * Improve thread safty of get_connection_by_slot and get_connection_by_node methods (iandyh)
     * Improved error handling when sending commands to all nodes, e.g. info. Now the connection takes retry_on_timeout as an option and retry once when there is a timeout. (iandyh)
+    * Added support for SCRIPT LOAD, SCRIPT FLUSH, SCRIPT EXISTS and EVALSHA commands. (alisaifee)
 
 * 1.0.0
     * No change to anything just a bump to 1.0.0 because the lib is now considered stable/production ready.

--- a/docs/Authors
+++ b/docs/Authors
@@ -20,3 +20,4 @@ Authors who contributed code or testing:
  - iandyh - https://github.com/iandyh
  - mumumu - https://github.com/mumumu
  - awestendorf - https://github.com/awestendorf
+ - Ali-Akber Saifee - https://github.com/alisaifee

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -26,7 +26,6 @@ The following commands will send the same request to all nodes in the cluster. R
  - lastsave
  - ping
  - save
- - script_flush
  - slowlog_get
  - slowlog_len
  - slowlog_reset
@@ -42,13 +41,21 @@ The following commands will only be send to the master nodes in the cluster. Res
  - flushdb
  - scan
 
+
 This command will sent to a random node in the cluster.
 
  - publish
 
-This command will be sent to the server that matches the first key.
+The following commands will be sent to the server that matches the first key.
 
  - eval
+ - evalsha
+
+This following commands will be sent to the master nodes in the cluster.
+
+- script load - the result is the hash of loaded script
+- script flush - the result is `True` if the command succeeds on all master nodes, else `False`
+- script exists - the result is an array of booleans. An entry is `True` only if the script exists on all the master nodes.
 
 The following commands will be sent to the sever that matches the specefied key.
 
@@ -70,13 +77,9 @@ Either because they do not work, there is no working implementation or it is not
 
  - bitop - Currently to hard to implement a solution in python space
  - client_setname - Not yet implemented
- - evalsha - Lua scripting is not yet implemented
  - move - It is not possible to move a key from one db to another in cluster mode
- - register_script - Lua scripting is not yet implemented
  - restore
- - script_exists - Lua scripting is not yet implemented
- - script_kill - Lua scripting is not yet implemented
- - script_load - Lua scripting is not yet implemented
+ - script_kill - Not yet implemented
  - sentinel
  - sentinel_get_master_addr_by_name
  - sentinel_master

--- a/docs/Scripting.md
+++ b/docs/Scripting.md
@@ -1,0 +1,27 @@
+# Scripting support
+
+Scripting support is limited to scripts that operate on keys in the same key slot.
+If a script is executed via `evalsha`, `eval` or by calling the callable returned by
+`register_script` and the keys passed as arguments do not map to the same key slot,
+a `RedisClusterException` will be thrown.
+
+It is however, possible to query a key within the script, that is not passed
+as an argument of `eval`, `evalsha`. In this scenarios it is not possible to detect
+the error early and redis itself will raise an error which will be percolated
+to the user. For example:
+
+```python
+    cluster = RedisCluster('localhost', 7000)
+    script = """
+    return redis.call('GET', KEYS[1]) * redis.call('GET', ARGV[1])
+    """
+    # this will succeed
+    cluster.eval(script, 1, "A{Foo}", "A{Foo}")
+    # this will fail as "A{Foo}" and "A{Bar}" are on different key slots.
+    cluster.eval(script, 1, "A{Foo}", "A{Bar}")
+```
+
+## Unsupported operations
+
+- The `SCRIPT KILL` command is not yet implemented.
+- Scripting in the context of a pipeline is not yet implemented.

--- a/tests/test_cluster_obj.py
+++ b/tests/test_cluster_obj.py
@@ -72,8 +72,7 @@ def test_blocked_commands(r):
     blocked_commands = [
         "CLIENT SETNAME", "SENTINEL GET-MASTER-ADDR-BY-NAME", 'SENTINEL MASTER', 'SENTINEL MASTERS',
         'SENTINEL MONITOR', 'SENTINEL REMOVE', 'SENTINEL SENTINELS', 'SENTINEL SET',
-        'SENTINEL SLAVES', 'SHUTDOWN', 'SLAVEOF', 'EVALSHA', 'SCRIPT EXISTS', 'SCRIPT KILL',
-        'SCRIPT LOAD', 'MOVE', 'BITOP',
+        'SENTINEL SLAVES', 'SHUTDOWN', 'SLAVEOF', 'SCRIPT KILL', 'MOVE', 'BITOP',
     ]
 
     for command in blocked_commands:

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -18,7 +18,6 @@ value = tonumber(value)
 return value * ARGV[1]"""
 
 
-@pytest.mark.xfail(reason="scripting is not yet supported")
 class TestScripting(object):
     @pytest.fixture(autouse=True)
     def reset_scripts(self, r):
@@ -59,14 +58,12 @@ class TestScripting(object):
         with pytest.raises(RedisClusterException):
             r.eval(script, 2, 'A{foo}', 'B{bar}')
 
-    @pytest.mark.xfail(reason="Not Yet Implemented")
     def test_evalsha(self, r):
         r.set('a', 2)
         sha = r.script_load(multiply_script)
         # 2 * 3 == 6
         assert r.evalsha(sha, 1, 'a', 3) == 6
 
-    @pytest.mark.xfail(reason="Not Yet Implemented")
     def test_evalsha_script_not_loaded(self, r):
         r.set('a', 2)
         sha = r.script_load(multiply_script)
@@ -75,7 +72,6 @@ class TestScripting(object):
         with pytest.raises(exceptions.NoScriptError):
             r.evalsha(sha, 1, 'a', 3)
 
-    @pytest.mark.xfail(reason="Not Yet Implemented")
     def test_script_loading(self, r):
         # get the sha, then clear the cache
         sha = r.script_load(multiply_script)
@@ -84,7 +80,6 @@ class TestScripting(object):
         r.script_load(multiply_script)
         assert r.script_exists(sha) == [True]
 
-    @pytest.mark.xfail(reason="Not Yet Implemented")
     def test_script_object(self, r):
         r.set('a', 2)
         multiply = r.register_script(multiply_script)


### PR DESCRIPTION
Testing done
 * As per tests in [test_scripting.py](https://github.com/alisaifee/redis-py-cluster/blob/script-loading/tests/test_scripting.py)
 * Calling a registered script against a slot on a new node which doesn't have the script loaded.
 * Calling a registered csript on a slot that was moved to a different node which doesn't have the script loaded.

Not implemented
 * `SCRIPT KILL`
 * loading a script in a pipeline.