### PR TITLE
removed assert from evaluation of dict, func: utils.is_dict.

### DIFF
--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -11,9 +11,7 @@ def is_dict(d):
     """
     Test if variable is a dict or not.
     """
-    if isinstance(d, dict):
-        return True
-    return None
+    return  isinstance(d, dict)
 
 
 def string_keys_to_dict(key_strings, callback):
@@ -51,15 +49,16 @@ def merge_result(command, res):
     This command is used when sending a command to multiple nodes
     and they result from each node should be merged into a single list.
     """
-    is_dict(res)
+    if is_dict(res):
 
-    result = set([])
+        result = set([])
 
-    for _, v in res.items():
-        for value in v:
-            result.add(value)
+        for _, v in res.items():
+            for value in v:
+                result.add(value)
 
-    return list(result)
+        return list(result)
+    return None
 
 
 def first_key(command, res):
@@ -68,12 +67,12 @@ def first_key(command, res):
 
     If more then 1 result is returned then a `RedisClusterException` is raised.
     """
-    is_dict(res)
+    if is_dict(res):
 
-    if len(res.keys()) != 1:
-        raise RedisClusterException("More then 1 result from command: {0}".format(command))
+        if len(res.keys()) != 1:
+            raise RedisClusterException("More then 1 result from command: {0}".format(command))
 
-    return list(res.values())[0]
+        return list(res.values())[0]
 
 
 def clusterdown_wrapper(func):

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -11,9 +11,9 @@ def is_dict(d):
     """
     Test if variable is a dict or not.
     """
-    assert isinstance(d, dict)
-
-    return True
+    if isinstance(d, dict):
+        return True
+    return None
 
 
 def string_keys_to_dict(key_strings, callback):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,8 +32,8 @@ def test_dict_merge():
     c = {"c": 3}
     assert dict_merge(a, b, c) == {"a": 1, "b": 2, "c": 3}
 
-    with pytest.raises(AssertionError):
-        dict_merge([])
+    #with pytest.raises(AssertionError):
+    assert dict_merge([]) == dict()
 
 
 def test_blocked_command():
@@ -46,8 +46,8 @@ def test_merge_result():
     assert merge_result("foobar", {"a": [1, 2, 3], "b": [4, 5, 6]}) == [1, 2, 3, 4, 5, 6]
     assert merge_result("foobar", {"a": [1, 2, 3], "b": [1, 2, 3]}) == [1, 2, 3]
 
-    with pytest.raises(AssertionError):
-        merge_result("foobar", [])
+   # with pytest.raises(AssertionError):
+    assert merge_result("foobar", []) == None
 
 
 def test_first_key():
@@ -57,8 +57,8 @@ def test_first_key():
         first_key("foobar", {"foo": 1, "bar": 2})
     assert unicode(ex.value).startswith("More then 1 result from command: foobar")
 
-    with pytest.raises(AssertionError):
-        first_key("foobar", None)
+    #with pytest.raises(AssertionError):
+    assert first_key("foobar", None) == None
 
 
 def test_clusterdown_wrapper():


### PR DESCRIPTION
Removing assert from utils.is_dict. Removing the risk of executing the passed down variable when assert  evaluates the variable. In addition set a default None return, since Nothing is already expected upstream.