### PR TITLE
Allow passing in a custom connection pool

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
     * Rework pfcount to now work as expected when all arguments points to same hashslot
     * New code and important changes from redis-py 2.10.5 have been added to the codebase.
     * Removed the need for threads inside of pipeline. We write the packed commands all nodes before reading the responses which gives us even better performance than threads, especially as we add more nodes to the cluster.
+    * Allow passing in a custom connection pool
 
 * 1.1.0
     * Refactored exception handling and exception classes.


### PR DESCRIPTION
Using this to support async cluster connections with greenlets and tornado. That code will live in http://github.com/svrana/gretis