### PR TITLE
Provide default value for max_connections

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
     * New code and important changes from redis-py 2.10.5 have been added to the codebase.
     * Removed the need for threads inside of pipeline. We write the packed commands all nodes before reading the responses which gives us even better performance than threads, especially as we add more nodes to the cluster.
     * Allow passing in a custom connection pool
+    * Provide default max_connections value for ClusterConnectionPool (2**31)
 
 * 1.1.0
     * Refactored exception handling and exception classes.

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -69,6 +69,7 @@ class ClusterConnectionPool(ConnectionPool):
                  max_connections=None, max_connections_per_node=False, **connection_kwargs):
         super(ClusterConnectionPool, self).__init__(connection_class=connection_class, max_connections=max_connections)
 
+        self.max_connections = max_connections or 2 ** 31
         self.max_connections_per_node = max_connections_per_node
 
         self.nodes = NodeManager(startup_nodes, **connection_kwargs)

--- a/tests/test_cluster_connection_pool.py
+++ b/tests/test_cluster_connection_pool.py
@@ -74,6 +74,10 @@ class TestConnectionPool(object):
         with pytest.raises(RedisClusterException):
             pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
 
+    def test_max_connections_default_setting(self):
+        pool = self.get_pool(max_connections=None)
+        assert pool.max_connections == 2 ** 31
+
     def test_reuse_previously_released_connection(self):
         pool = self.get_pool()
         c1 = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})


### PR DESCRIPTION
The default of 2**31 basically turns off the max_connections logic
which will be familiar to people migrating from redis-py.