### PR TITLE
make cluster down decorator work with instrumentation

### DIFF
--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from socket import gethostbyaddr
+from functools import wraps
 
 # rediscluster imports
 from .exceptions import (
@@ -82,6 +83,7 @@ def clusterdown_wrapper(func):
 
     It will try 3 times to rerun the command and raises ClusterDownException if it continues to fail.
     """
+    @wraps(func)
     def inner(*args, **kwargs):
         for _ in range(0, 3):
             try:


### PR DESCRIPTION
See: http://stackoverflow.com/questions/308999/what-does-functools-wraps-do

when instrumenting methods with this decorator, it reports the wrong method name. This patch should fix it. There might be other methods like this, but this is the most obvious one I saw.