### PR TITLE
Cluster could respond if redis doesn't require full coverage

### DIFF
--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -170,7 +170,7 @@ class NodeManager(object):
             # Validate if all slots are covered or if we should try next startup node
             for i in range(0, self.RedisClusterHashSlots):
                 if i not in tmp_slots:
-                    if not self.is_cluster_up():
+                    if self.cluster_require_full_coverage(nodes_cache):
                         all_slots_covered = False
 
             if all_slots_covered:
@@ -191,22 +191,23 @@ class NodeManager(object):
 
         self.determine_pubsub_node()
 
-    def is_cluster_up(self):
+    def cluster_require_full_coverage(self, nodes_cache):
         """
         if exists 'cluster-require-full-coverage no' config on redis servers,
         then even all slots are not covered, cluster still will be able to
         respond
         """
-        # get random node
-        node = self.orig_startup_nodes[0]
-        r = self.get_redis_link(host=node["host"], port=node["port"])
-        # get cluster info
-        cluster_info = r.execute_command("cluster", "info")
-        # parse cluster_state
-        for info in cluster_info.split("\r\n"):
-            if "cluster_state" in info:
-                return info.split(":")[1] == 'ok'
-        return False
+        nodes = self.nodes or nodes_cache
+
+        def node_require_full_coverage(node):
+            r_node = self.get_redis_link(host=node["host"], port=node["port"],
+                                         decode_responses=True)
+            return "yes" in r_node.config_get(
+                "cluster-require-full-coverage").values()
+
+        # at least one node should have cluster-require-full-coverage yes
+        return any(
+            node_require_full_coverage(node) for node in nodes.values())
 
     def determine_pubsub_node(self):
         """

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -170,7 +170,8 @@ class NodeManager(object):
             # Validate if all slots are covered or if we should try next startup node
             for i in range(0, self.RedisClusterHashSlots):
                 if i not in tmp_slots:
-                    all_slots_covered = False
+                    if not self.is_cluster_up():
+                        all_slots_covered = False
 
             if all_slots_covered:
                 # All slots are covered and application can continue to execute
@@ -189,6 +190,23 @@ class NodeManager(object):
         self.nodes = nodes_cache
 
         self.determine_pubsub_node()
+
+    def is_cluster_up(self):
+        """
+        if exists 'cluster-require-full-coverage no' config on redis servers,
+        then even all slots are not covered, cluster still will be able to
+        respond
+        """
+        # get random node
+        node = self.orig_startup_nodes[0]
+        r = self.get_redis_link(host=node["host"], port=node["port"])
+        # get cluster info
+        cluster_info = r.execute_command("cluster", "info")
+        # parse cluster_state
+        for info in cluster_info.split("\r\n"):
+            if "cluster_state" in info:
+                return info.split(":")[1] == 'ok'
+        return False
 
     def determine_pubsub_node(self):
         """


### PR DESCRIPTION
I have faced the issue while working on the company. One slot will be deleted somehow and cluster covered 16383 slots that it is not reachable according to redis-py-cluster. But redis has config to disable it using "cluster-require-full-coverage no" and we are using it. If even all slots are not covered then cluster still can be able respond. Currently each redis servers have the above config but we can not use it because of node manager all slots coverage check. With this PR, everyone will be able to use redis-py-cluster client with this config. 