### PR TITLE
Fix a bug that was returned the key nodes_callbacks that was removed

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -1020,7 +1020,6 @@ class RedisCluster(StrictRedisCluster):
             connection_pool=self.connection_pool,
             startup_nodes=self.connection_pool.nodes.startup_nodes,
             refresh_table_asap=self.refresh_table_asap,
-            nodes_callbacks=self.nodes_callbacks,
             response_callbacks=self.response_callbacks
         )
 


### PR DESCRIPTION
- The changes was made in the commit 4a953420e004385f6783b34ed43755e1e0c5ebd3.
     First was removed in line 146 but had other change in 1024 that returned the key.