### PR TITLE
Fix for Python 3 bytes key.  fix #153.

### DIFF
--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -2,6 +2,7 @@
 
 # python std lib
 import random
+import sys
 
 # rediscluster imports
 from .crc import crc16
@@ -9,7 +10,7 @@ from .exceptions import RedisClusterException
 
 # 3rd party imports
 from redis import StrictRedis
-from redis._compat import unicode
+# from redis._compat import unicode
 from redis import ConnectionError
 
 
@@ -36,7 +37,13 @@ class NodeManager(object):
 
         This also works for binary keys that is used in python 3.
         """
-        k = unicode(key)
+        if sys.version_info[0] < 3:
+            k = unicode(key)
+        else:
+            try:
+                k = str(key, encoding='utf-8')  # bytes
+            except TypeError:  # Convert others to str.
+                k = str(key)
         start = k.find("{")
 
         if start > -1:


### PR DESCRIPTION
It the key is bytes in Python 3, unicode(key) would be str(key), which is just an string representation of the bytes. We must provide encoding to convert it to an str type. I hope this fix the problem.