### PR TITLE
Support for multi key commands MGET & MSET to pipelines

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -7,6 +7,9 @@ Next release (??? ??, 201?)
     * Fix a bug where from_url was not possible to use without passing in additional variables. Now it works as the same method from redis-py.
       Note that the same rules that is currently in place for passing ip addresses/dns names into startup_nodes variable apply the same way through
       the from_url method.
+    * Implement basic support for validating pipeline command stack when using multi key commands MSET & MGET to validate all keys used
+      points to the same cluster hash slot. Will raise exception if StrictRedisCluster object is not configured with new option `pipeline_allow_same_slot_commands=True`
+      that will enable validation of the commadn stack.
 
 
 1.3.1 (Oct 13, 2016)

--- a/ptp-debug.py
+++ b/ptp-debug.py
@@ -3,7 +3,13 @@ from rediscluster import StrictRedisCluster
 startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
 # Note: decode_responses must be set to True when used with python3
-rc = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True)
+rc = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True, pipeline_allow_same_slot_commands=True)
 url_client = StrictRedisCluster.from_url('http://127.0.0.1:7000')
+
+rc.set("{asd}foo", "bar")
+p = rc.pipeline()
+p.mget('{asd}foo', '{asd}bar', '{asd}wqe')
+p.mset({'{asd}qwe': 'ewq', '{asd}wer': 'rew'})
+print(p.execute())
 
 __import__('ptpdb').set_trace()

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -113,7 +113,7 @@ class StrictRedisCluster(StrictRedis):
     }
 
     def __init__(self, host=None, port=None, startup_nodes=None, max_connections=32, max_connections_per_node=False, init_slot_cache=True,
-                 readonly_mode=False, reinitialize_steps=None, **kwargs):
+                 readonly_mode=False, reinitialize_steps=None, pipeline_allow_same_slot_commands=False, **kwargs):
         """
         :startup_nodes:
             List of nodes that initial bootstrapping can be done from
@@ -166,6 +166,7 @@ class StrictRedisCluster(StrictRedis):
         self.result_callbacks = self.__class__.RESULT_CALLBACKS.copy()
         self.response_callbacks = self.__class__.RESPONSE_CALLBACKS.copy()
         self.response_callbacks = dict_merge(self.response_callbacks, self.CLUSTER_COMMANDS_RESPONSE_CALLBACKS)
+        self.pipeline_allow_same_slot_commands = pipeline_allow_same_slot_commands
 
     @classmethod
     def from_url(cls, url, db=None, **kwargs):
@@ -221,6 +222,7 @@ class StrictRedisCluster(StrictRedis):
             startup_nodes=self.connection_pool.nodes.startup_nodes,
             result_callbacks=self.result_callbacks,
             response_callbacks=self.response_callbacks,
+            allow_same_slot_commands=self.pipeline_allow_same_slot_commands
         )
 
     def transaction(self, *args, **kwargs):


### PR DESCRIPTION
First itteration to enable support for MGET and MSET when used to same hash slot when used in pipelines.
