### PR TITLE
Added options to skip full coverage check

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -20,3 +20,4 @@ Authors who contributed code or testing:
  - gmolight - https://github.com/gmolight
  - baranbartu - https://github.com/baranbartu
  - monklof - https://github.com/monklof
+ - dutradda - https://github.com/dutradda

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -7,6 +7,7 @@ Next release (??? ??, 201?)
     * Fix a bug where from_url was not possible to use without passing in additional variables. Now it works as the same method from redis-py.
       Note that the same rules that is currently in place for passing ip addresses/dns names into startup_nodes variable apply the same way through
       the from_url method.
+    * Added options to skip full coverage check. This flag is useful when the CONFIG redis command is disabled by the server.
 
 
 1.3.1 (Oct 13, 2016)

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -113,7 +113,7 @@ class StrictRedisCluster(StrictRedis):
     }
 
     def __init__(self, host=None, port=None, startup_nodes=None, max_connections=32, max_connections_per_node=False, init_slot_cache=True,
-                 readonly_mode=False, reinitialize_steps=None, **kwargs):
+                 readonly_mode=False, reinitialize_steps=None, skip_full_coverage_check=False, **kwargs):
         """
         :startup_nodes:
             List of nodes that initial bootstrapping can be done from
@@ -125,6 +125,9 @@ class StrictRedisCluster(StrictRedis):
             Maximum number of connections that should be kept open at one time
         :readonly_mode:
             enable READONLY mode. You can read possibly stale data from slave.
+        :skip_full_coverage_check:
+            Skips the check of cluster-require-full-coverage config, useful for clusters
+            without the CONFIG command (like aws)
         :**kwargs:
             Extra arguments that will be sent into StrictRedis instance when created
             (See Official redis-py doc for supported kwargs
@@ -156,6 +159,7 @@ class StrictRedisCluster(StrictRedis):
                 max_connections=max_connections,
                 reinitialize_steps=reinitialize_steps,
                 max_connections_per_node=max_connections_per_node,
+                skip_full_coverage_check=skip_full_coverage_check,
                 **kwargs
             )
 
@@ -168,7 +172,7 @@ class StrictRedisCluster(StrictRedis):
         self.response_callbacks = dict_merge(self.response_callbacks, self.CLUSTER_COMMANDS_RESPONSE_CALLBACKS)
 
     @classmethod
-    def from_url(cls, url, db=None, **kwargs):
+    def from_url(cls, url, db=None, skip_full_coverage_check=False, **kwargs):
         """
         Return a Redis client object configured from the given URL, which must
         use either `the ``redis://`` scheme
@@ -189,7 +193,7 @@ class StrictRedisCluster(StrictRedis):
         of conflicting arguments, querystring arguments always win.
         """
         connection_pool = ClusterConnectionPool.from_url(url, db=db, **kwargs)
-        return cls(connection_pool=connection_pool)
+        return cls(connection_pool=connection_pool, skip_full_coverage_check=skip_full_coverage_check)
 
     def __repr__(self):
         """

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -70,8 +70,12 @@ class ClusterConnectionPool(ConnectionPool):
     RedisClusterDefaultTimeout = None
 
     def __init__(self, startup_nodes=None, init_slot_cache=True, connection_class=ClusterConnection,
-                 max_connections=None, max_connections_per_node=False, reinitialize_steps=None, **connection_kwargs):
+                 max_connections=None, max_connections_per_node=False, reinitialize_steps=None,
+                 skip_full_coverage_check=False, **connection_kwargs):
         """
+        :skip_full_coverage_check:
+            Skips the check of cluster-require-full-coverage config, useful for clusters
+            without the CONFIG command (like aws)
         """
         super(ClusterConnectionPool, self).__init__(connection_class=connection_class, max_connections=max_connections)
 
@@ -90,7 +94,8 @@ class ClusterConnectionPool(ConnectionPool):
         self.max_connections = max_connections or 2 ** 31
         self.max_connections_per_node = max_connections_per_node
 
-        self.nodes = NodeManager(startup_nodes, reinitialize_steps=reinitialize_steps, **connection_kwargs)
+        self.nodes = NodeManager(startup_nodes, reinitialize_steps=reinitialize_steps,
+                                 skip_full_coverage_check=skip_full_coverage_check, **connection_kwargs)
         if init_slot_cache:
             self.nodes.initialize()
 


### PR DESCRIPTION
I wrote this patch because the AWS Elasticache disables the CONFIG command. Recently aws launched the redis 3.2 engine.
