### PR TITLE
Add support for bytes keys that are not utf-8 compatible

### DIFF
--- a/rediscluster/crc.py
+++ b/rediscluster/crc.py
@@ -43,7 +43,9 @@ def _crc16_py3(data):
     """
     """
     crc = 0
-    for byte in data.encode("utf-8"):
+    if hasattr(data, "encode"):
+        data = data.encode("utf-8")
+    for byte in data:
         crc = ((crc << 8) & 0xff00) ^ x_mode_m_crc16_lookup[((crc >> 8) & 0xff) ^ byte]
     return crc & 0xffff
 

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -67,8 +67,10 @@ class NodeManager(object):
         """
         if hasattr(key, "encode"):
             k = key.encode("utf-8")
-        else:
+        elif hasattr(key, "decode"):
             k = key
+        else:
+            k = str(key).encode()
 
         start = k.find(b"{")
 

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -65,17 +65,15 @@ class NodeManager(object):
         Calculate keyslot for a given key.
         Tuned for compatibility with supported python 3.x versions
         """
-        try:
-            # Handle bytes case
-            k = str(key, encoding='utf-8')
-        except TypeError:
-            # Convert others to str.
-            k = str(key)
+        if hasattr(key, "encode"):
+            k = key.encode("utf-8")
+        else:
+            k = key
 
-        start = k.find("{")
+        start = k.find(b"{")
 
         if start > -1:
-            end = k.find("}", start + 1)
+            end = k.find(b"}", start + 1)
             if end > -1 and end != start + 1:
                 k = k[start + 1:end]
 


### PR DESCRIPTION
The change enables the support of all possible bytes object as the redis-py library does. As of now if bytes that are not available in utf-8 are used in keys, the client crashes:
```
>>> con = rediscluster.StrictRedisCluster(startup_nodes=NODES)
[{'port': '6379', 'host': '213.244.194.42'}, {'port': '6379', 'host': '213.244.194.43'}, {'port': '6379', 'host': '213.244.194.44'}, {'port': '6379', 'host': '213.244.194.70'}, {'port': '6379', 'host': '213.244.194.78'}, {'port': '6379', 'host': '213.244.194.81'}]
>>> con.set(b'\x01', 0x01)
True
>>> con.set(b'\xa1', 0xa1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.5/site-packages/redis/client.py", line 1072, in set
    return self.execute_command('SET', *pieces)
  File "/home/abe/research/libcmonger/rediscluster/utils.py", line 101, in inner
    return func(*args, **kwargs)
  File "/home/abe/research/libcmonger/rediscluster/client.py", line 308, in execute_command
    slot = self._determine_slot(*args)
  File "/home/abe/research/libcmonger/rediscluster/client.py", line 254, in _determine_slot
    return self.connection_pool.nodes.keyslot(key)
  File "/home/abe/research/libcmonger/rediscluster/nodemanager.py", line 70, in keyslot_py_3
    k = str(key, encoding='utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa1 in position 0: invalid start byte
```

Instead of converting a bytes back to str, just use bytes for all keys as redis-py does:
```
>>> con.set(b'\xa1', 0xa1)
True
>>> hex(int(con.get(b'\xa1')))
'0xa1'
```