### PR TITLE
Convert raw responses from Redis to native strings in CLUSTER command parsing, allowing the use of decode_responses=False in Python 3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Small sample script that shows how to get started with RedisCluster. It can also
 >>> # Requires at least one node for cluster discovery. Multiple nodes is recommended.
 >>> startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
->>> # Note: decode_responses must be set to True when used with python3
 >>> rc = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True)
 
 >>> rc.set("foo", "bar")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Small sample script that shows how to get started with RedisCluster. It can also
     >>> # Requires at least one node for cluster discovery. Multiple nodes is recommended.
     >>> startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
-    >>> # Note: decode_responses must be set to True when used with python3
+    >>> # Note: decode_responses behaves differently with python3 and python2
     >>> rc = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True)
 
     >>> rc.set("foo", "bar")
@@ -52,7 +52,9 @@ Small sample script that shows how to get started with RedisCluster. It can also
     >>> print(rc.get("foo"))
     'bar'
 
+.. note:: Python 3
 
+    Since Python 3 changed to Unicode strings from Python 2's ASCII, the return type of *most* commands will be binary strings, unless the class is instantiated with the option ``decode_responses=True``. In this case, the responses will be Python strings (Unicode). Even if ``decode_responses`` is false, the cluster methods ``cluster_nodes`` and ``cluster_slots`` will return a decoded python string.
 
 Dependencies & supported python versions
 ----------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Small sample script that shows how to get started with RedisCluster. It can also
     >>> # Requires at least one node for cluster discovery. Multiple nodes is recommended.
     >>> startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
-    >>> # Note: decode_responses behaves differently with python3 and python2
+    >>> # Note: decode_responses gives different results with python3 and python2
     >>> rc = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True)
 
     >>> rc.set("foo", "bar")
@@ -52,9 +52,12 @@ Small sample script that shows how to get started with RedisCluster. It can also
     >>> print(rc.get("foo"))
     'bar'
 
+It is fairly safe to assume that any methods not documented here wil behave in the same way as
+*redis-py* (https://github.com/andymccurdy/redis-py/)
+
 .. note:: Python 3
 
-    Since Python 3 changed to Unicode strings from Python 2's ASCII, the return type of *most* commands will be binary strings, unless the class is instantiated with the option ``decode_responses=True``. In this case, the responses will be Python strings (Unicode). Even if ``decode_responses`` is false, the cluster methods ``cluster_nodes`` and ``cluster_slots`` will return a decoded python string.
+    Since Python 3 changed to Unicode strings from Python 2's ASCII, the return type of *most* commands will be binary strings, unless the class is instantiated with the option ``decode_responses=True``. In this case, the responses will be Python 3 strings (Unicode).
 
 Dependencies & supported python versions
 ----------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Small sample script that shows how to get started with RedisCluster. It can also
     >>> # Requires at least one node for cluster discovery. Multiple nodes is recommended.
     >>> startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
-    >>> # Note: decode_responses gives different results with python3 and python2
+    >>> # Note: See note on Python 3 for decode_responses behaviour
     >>> rc = StrictRedisCluster(startup_nodes=startup_nodes, decode_responses=True)
 
     >>> rc.set("foo", "bar")
@@ -52,12 +52,10 @@ Small sample script that shows how to get started with RedisCluster. It can also
     >>> print(rc.get("foo"))
     'bar'
 
-It is fairly safe to assume that any methods not documented here wil behave in the same way as
-*redis-py* (https://github.com/andymccurdy/redis-py/)
 
 .. note:: Python 3
 
-    Since Python 3 changed to Unicode strings from Python 2's ASCII, the return type of *most* commands will be binary strings, unless the class is instantiated with the option ``decode_responses=True``. In this case, the responses will be Python 3 strings (Unicode).
+    Since Python 3 changed to Unicode strings from Python 2's ASCII, the return type of *most* commands will be binary strings, unless the class is instantiated with the option ``decode_responses=True``. In this case, the responses will be Python 3 strings (Unicode). For the init argument `decode_responses`, when set to False, redis-py-cluster will not attempt to decode the responses it receives. In Python 3, this means the responses will be of type `bytes`. In Python 2, they will be native strings (`str`). If `decode_responses` is set to True, for Python 3 responses will be `str`, for Python 2 they will be `unicode`.
 
 Dependencies & supported python versions
 ----------------------------------------

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -123,6 +123,9 @@ def nslookup(node_ip):
 def parse_cluster_slots(resp, **options):
     """
     """
+    if type(resp) is bytes:
+        resp = resp.decode('UTF-8')
+
     current_host = options.get('current_host', '')
 
     def fix_server(*args):
@@ -145,6 +148,9 @@ def parse_cluster_nodes(resp, **options):
     @see: http://redis.io/commands/cluster-nodes  # string
     @see: http://redis.io/commands/cluster-slaves # list of string
     """
+    if type(resp) is bytes:
+        resp = resp.decode('UTF-8')
+
     current_host = options.get('current_host', '')
 
     def parse_slots(s):

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -123,13 +123,10 @@ def nslookup(node_ip):
 def parse_cluster_slots(resp, **options):
     """
     """
-    if type(resp) is bytes:
-        resp = resp.decode('UTF-8')
-
     current_host = options.get('current_host', '')
 
     def fix_server(*args):
-        return (args[0] or current_host, args[1])
+        return (nativestr(args[0]) or current_host, args[1])
 
     slots = {}
     for slot in resp:
@@ -148,9 +145,7 @@ def parse_cluster_nodes(resp, **options):
     @see: http://redis.io/commands/cluster-nodes  # string
     @see: http://redis.io/commands/cluster-slaves # list of string
     """
-    if type(resp) is bytes:
-        resp = resp.decode('UTF-8')
-
+    resp = nativestr(resp)
     current_host = options.get('current_host', '')
 
     def parse_slots(s):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ from rediscluster.utils import (
 
 # 3rd party imports
 import pytest
-from redis._compat import unicode
+from redis._compat import unicode, b
 
 
 def test_parse_cluster_slots():
@@ -69,6 +69,29 @@ def test_parse_cluster_slots():
     ]
 
     parse_cluster_slots(extended_mock_response)
+
+    mock_binary_response = [
+        [0, 5460, [b('172.17.0.2'), 7000], [b('172.17.0.2'), 7003]],
+        [5461, 10922, [b('172.17.0.2'), 7001], [b('172.17.0.2'), 7004]],
+        [10923, 16383, [b('172.17.0.2'), 7002], [b('172.17.0.2'), 7005]]
+    ]
+    parse_cluster_slots(mock_binary_response)
+
+    extended_mock_binary_response = [
+        [0, 5460, [b('172.17.0.2'), 7000, b('ffd36d8d7cb10d813f81f9662a835f6beea72677')], [b('172.17.0.2'), 7003, b('5c15b69186017ddc25ebfac81e74694fc0c1a160')]],
+        [5461, 10922, [b('172.17.0.2'), 7001, b('069cda388c7c41c62abe892d9e0a2d55fbf5ffd5')], [b('172.17.0.2'), 7004, b('dc152a08b4cf1f2a0baf775fb86ad0938cb907dc')]],
+        [10923, 16383, [b('172.17.0.2'), 7002, b('3588b4cf9fc72d57bb262a024747797ead0cf7ea')], [b('172.17.0.2'), 7005, b('a72c02c7d85f4ec3145ab2c411eefc0812aa96b0')]]
+    ]
+
+    extended_mock_parsed = {
+        (0, 5460): {'master': ('172.17.0.2', 7000), 'slaves': [('172.17.0.2', 7003)]},
+        (5461, 10922): {'master': ('172.17.0.2', 7001),
+                        'slaves': [('172.17.0.2', 7004)]},
+        (10923, 16383): {'master': ('172.17.0.2', 7002),
+                         'slaves': [('172.17.0.2', 7005)]}
+    }
+
+    assert parse_cluster_slots(extended_mock_binary_response) == extended_mock_parsed
 
 
 def test_string_keys_to():


### PR DESCRIPTION
Using `nativestr` from `redis._compat` to convert responses passed to the parsing callbacks `parse_cluster_nodes` and `parse_cluster_slots` in `rediscluster/utils.py`. 

This addresses issue #171 where undecoded responses in Python 3 are of type `bytes`, which iterates per-byte as opposed to per-line like `str`, breaking the parsing method.