### PR TITLE
nodemanager to honor max_connections

### DIFF
--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -95,7 +95,7 @@ class ClusterConnectionPool(ConnectionPool):
         self.max_connections_per_node = max_connections_per_node
 
         self.nodes = NodeManager(startup_nodes, reinitialize_steps=reinitialize_steps,
-                                 skip_full_coverage_check=skip_full_coverage_check, **connection_kwargs)
+                                 skip_full_coverage_check=skip_full_coverage_check, max_connections=max_connections, **connection_kwargs)
         if init_slot_cache:
             self.nodes.initialize()
 

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -19,13 +19,14 @@ class NodeManager(object):
     """
     RedisClusterHashSlots = 16384
 
-    def __init__(self, startup_nodes=None, reinitialize_steps=None, skip_full_coverage_check=False, **connection_kwargs):
+    def __init__(self, startup_nodes=None, reinitialize_steps=None, skip_full_coverage_check=False, max_connections=None, **connection_kwargs):
         """
         :skip_full_coverage_check:
             Skips the check of cluster-require-full-coverage config, useful for clusters
             without the CONFIG command (like aws)
         """
         self.connection_kwargs = connection_kwargs
+        self.max_connections=max_connections
         self.nodes = {}
         self.slots = {}
         self.startup_nodes = [] if startup_nodes is None else startup_nodes
@@ -155,7 +156,7 @@ class NodeManager(object):
             'decode_responses',
         )
         connection_kwargs = {k: v for k, v in self.connection_kwargs.items() if k in set(allowed_keys) - set(disabled_keys)}
-        return StrictRedis(host=host, port=port, decode_responses=decode_responses, **connection_kwargs)
+        return StrictRedis(host=host, port=port, decode_responses=decode_responses, max_connections=self.max_connections, **connection_kwargs)
 
     def initialize(self):
         """

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -19,14 +19,13 @@ class NodeManager(object):
     """
     RedisClusterHashSlots = 16384
 
-    def __init__(self, startup_nodes=None, reinitialize_steps=None, skip_full_coverage_check=False, max_connections=None, **connection_kwargs):
+    def __init__(self, startup_nodes=None, reinitialize_steps=None, skip_full_coverage_check=False, **connection_kwargs):
         """
         :skip_full_coverage_check:
             Skips the check of cluster-require-full-coverage config, useful for clusters
             without the CONFIG command (like aws)
         """
         self.connection_kwargs = connection_kwargs
-        self.max_connections=max_connections
         self.nodes = {}
         self.slots = {}
         self.startup_nodes = [] if startup_nodes is None else startup_nodes
@@ -156,7 +155,7 @@ class NodeManager(object):
             'decode_responses',
         )
         connection_kwargs = {k: v for k, v in self.connection_kwargs.items() if k in set(allowed_keys) - set(disabled_keys)}
-        return StrictRedis(host=host, port=port, decode_responses=decode_responses, max_connections=self.max_connections, **connection_kwargs)
+        return StrictRedis(host=host, port=port, decode_responses=decode_responses, **connection_kwargs)
 
     def initialize(self):
         """


### PR DESCRIPTION
It seems like that nodemanager doesn't honor max_connections set on a ClusterConnectionPool.

```
pool = ClusterConnectionPool(startup_nodes=[{'host': host, 'port': 6380}],
                             password=password,
                             max_connections_per_node=True,
                             max_connections=30,
                             socket_timeout=20,
                             socket_connect_timeout=10,
                             socket_keepalive=True,
                             )
```
With this pull requests Nodemanager would start passing the max_connections to StrictRedis 