### PR TITLE
Add PUBSUB * commands, sending to all nodes

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -21,3 +21,4 @@ Authors who contributed code or testing:
  - baranbartu - https://github.com/baranbartu
  - monklof - https://github.com/monklof
  - dutradda - https://github.com/dutradda
+ - AngusP - https://github.com/AngusP

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -33,6 +33,12 @@ The following commands will send the same request to all nodes in the cluster. R
  - slowlog_reset
  - time
 
+The pubsub commands are sent to all nodes, and the resulting replies are merged together. They have an optional keyword argument `aggregate` which when set to `False` will return a dict with k,v pair (NodeID, Result) instead of the merged result.
+
+ - pubsub_channels
+ - pubsub_numsub
+ - pubsub_numpat
+
 This command will send the same request to all nodes in the cluster in sequence. Results is appended to a unified list.
 
  - keys

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+Unstable
+--------
+
+    * Add support for `PUBSUB` subcommands `CHANNELS`, `NUMSUB [arg] [args...]` and `NUMPAT`.
+    * Add method `set_result_callback(command, callback)` allowing the default reply callbacks to be changed, in the same way `set_response_callback(command, callback)` inherited from Redis-Py does for responses.
+
 1.3.3 (Dec 15, 2016)
 --------------------
 

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -50,14 +50,14 @@ class StrictRedisCluster(StrictRedis):
             "ECHO", "CONFIG GET", "CONFIG SET", "SLOWLOG GET", "CLIENT KILL", "INFO",
             "BGREWRITEAOF", "BGSAVE", "CLIENT LIST", "CLIENT GETNAME", "CONFIG RESETSTAT",
             "CONFIG REWRITE", "DBSIZE", "LASTSAVE", "PING", "SAVE", "SLOWLOG LEN", "SLOWLOG RESET",
-            "TIME", "KEYS", "CLUSTER INFO",
+            "TIME", "KEYS", "CLUSTER INFO", "PUBSUB CHANNELS",  
+            "PUBSUB NUMSUB", "PUBSUB NUMPAT",
         ], 'all-nodes'),
         string_keys_to_dict([
             "FLUSHALL", "FLUSHDB", "SCRIPT LOAD", "SCRIPT FLUSH", "SCRIPT EXISTS", "SCAN",
         ], 'all-masters'),
         string_keys_to_dict([
-            "RANDOMKEY", "CLUSTER NODES", "CLUSTER SLOTS", "PUBSUB CHANNELS",  
-            "PUBSUB NUMSUB", "PUBSUB NUMPAT",
+            "RANDOMKEY", "CLUSTER NODES", "CLUSTER SLOTS",
         ], 'random'),
         string_keys_to_dict([
             "CLUSTER COUNTKEYSINSLOT",
@@ -71,6 +71,7 @@ class StrictRedisCluster(StrictRedis):
             "CONFIG REWRITE", "DBSIZE", "LASTSAVE", "PING", "SAVE", "SLOWLOG LEN", "SLOWLOG RESET",
             "TIME", "SCAN", "CLUSTER INFO", 'CLUSTER ADDSLOTS', 'CLUSTER COUNT-FAILURE-REPORTS',
             'CLUSTER DELSLOTS', 'CLUSTER FAILOVER', 'CLUSTER FORGET', "FLUSHALL", "FLUSHDB",
+            "PUBSUB CHANNELS", "PUBSUB NUMSUB", "PUBSUB NUMPAT",
         ], lambda command, res: res),
         string_keys_to_dict([
             "SCRIPT LOAD",

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -56,7 +56,8 @@ class StrictRedisCluster(StrictRedis):
             "FLUSHALL", "FLUSHDB", "SCRIPT LOAD", "SCRIPT FLUSH", "SCRIPT EXISTS", "SCAN",
         ], 'all-masters'),
         string_keys_to_dict([
-            "RANDOMKEY", "CLUSTER NODES", 'CLUSTER SLOTS',
+            "RANDOMKEY", "CLUSTER NODES", "CLUSTER SLOTS", "PUBSUB CHANNELS",  
+            "PUBSUB NUMSUB", "PUBSUB NUMPAT",
         ], 'random'),
         string_keys_to_dict([
             "CLUSTER COUNTKEYSINSLOT",

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -91,10 +91,10 @@ class StrictRedisCluster(StrictRedis):
             "SSCAN", "HSCAN", "ZSCAN", "RANDOMKEY",
         ], first_key),
         {
-            "PUBSUB CHANNELS" : parse_pubsub_channels,
-            "PUBSUB NUMSUB"   : parse_pubsub_numsub,
-            "PUBSUB NUMPAT"   : parse_pubsub_numpat,
-        },
+            "PUBSUB CHANNELS": parse_pubsub_channels,
+            "PUBSUB NUMSUB": parse_pubsub_numsub,
+            "PUBSUB NUMPAT": parse_pubsub_numpat,
+        }
     )
 
     CLUSTER_COMMANDS_RESPONSE_CALLBACKS = {
@@ -262,12 +262,12 @@ class StrictRedisCluster(StrictRedis):
 
         return self.connection_pool.nodes.keyslot(key)
 
-    def _merge_result(self, command, res):
+    def _merge_result(self, command, res, **kwargs):
         """
         `res` is a dict with the following structure Dict(NodeName, CommandResult)
         """
         if command in self.result_callbacks:
-            return self.result_callbacks[command](command, res)
+            return self.result_callbacks[command](command, res, **kwargs)
 
         # Default way to handle result
         return first_key(command, res)
@@ -399,7 +399,7 @@ class StrictRedisCluster(StrictRedis):
             finally:
                 self.connection_pool.release(connection)
 
-        return self._merge_result(command, res)
+        return self._merge_result(command, res, **kwargs)
 
     ##########
     # Cluster management commands
@@ -751,8 +751,7 @@ class StrictRedisCluster(StrictRedis):
         Return a list of channels that have at least one subscriber.
         Aggregate toggles merging of response.
         """
-        options = { 'aggregate': aggregate }
-        return self.execute_command('PUBSUB CHANNELS', pattern, **options)
+        return self.execute_command('PUBSUB CHANNELS', pattern, aggregate=aggregate)
 
 
     def pubsub_numpat(self, aggregate=True):
@@ -760,17 +759,17 @@ class StrictRedisCluster(StrictRedis):
         Returns the number of subscriptions to patterns.
         Aggregate toggles merging of response.
         """
-        options = { 'aggregate': aggregate }
-        return self.execute_command('PUBSUB NUMPAT', **options)
+        return self.execute_command('PUBSUB NUMPAT', aggregate=aggregate)
 
 
-    def pubsub_numsub(self, *args, aggregate=True):
+    def pubsub_numsub(self, *args, **kwargs):
         """
         Return a list of (channel, number of subscribers) tuples
         for each channel given in ``*args``.
-        Aggregate toggles merging of response.
+        
+        ``aggregate`` keyword argument toggles merging of response.
         """
-        options = { 'aggregate': aggregate }
+        options = { 'aggregate': kwargs.get('aggregate', True) }
         return self.execute_command('PUBSUB NUMSUB', *args, **options)
 
     ####

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -90,11 +90,15 @@ class StrictRedisCluster(StrictRedis):
         string_keys_to_dict([
             "SSCAN", "HSCAN", "ZSCAN", "RANDOMKEY",
         ], first_key),
-        {
-            "PUBSUB CHANNELS": parse_pubsub_channels,
-            "PUBSUB NUMSUB": parse_pubsub_numsub,
-            "PUBSUB NUMPAT": parse_pubsub_numpat,
-        }
+        string_keys_to_dict([
+            "PUBSUB CHANNELS",
+        ], parse_pubsub_channels),
+        string_keys_to_dict([
+            "PUBSUB NUMSUB",
+        ], parse_pubsub_numsub),
+        string_keys_to_dict([
+            "PUBSUB NUMPAT",
+        ], parse_pubsub_numpat),
     )
 
     CLUSTER_COMMANDS_RESPONSE_CALLBACKS = {
@@ -210,6 +214,10 @@ class StrictRedisCluster(StrictRedis):
         servers = list({'{0}:{1}'.format(nativestr(info['host']), info['port']) for info in self.connection_pool.nodes.startup_nodes})
         servers.sort()
         return "{0}<{1}>".format(type(self).__name__, ', '.join(servers))
+
+    def set_result_callback(self, command, callback):
+        "Set a custom Result Callback"
+        self.result_callbacks[command] = callback
 
     def pubsub(self, **kwargs):
         """
@@ -1140,7 +1148,7 @@ class StrictRedisCluster(StrictRedis):
         Generate a good random key with a low probability of collision between any other key.
         """
         # TODO: Check if the key exists or not. continue to randomize until a empty key is found
-        random_id = "{{{0}}}{1}".format(hashslot, self._random_id())
+        random_id = "{{0}}{1}".format(hashslot, self._random_id())
         return random_id
 
     def _random_id(self, size=16, chars=string.ascii_uppercase + string.digits):

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -203,3 +203,45 @@ def parse_cluster_nodes(resp, **options):
         nodes.append(node)
 
     return nodes
+
+
+def parse_pubsub_channels(command, resp, **options):
+    aggregate = options.get('aggregate', True)
+    if not aggregate:
+        return resp
+
+    nodes = resp.keys()
+    channels = set()
+    for node in nodes:
+        channels.update(resp[node])
+    return list(channels)
+    
+
+def parse_pubsub_numpat(command, resp, **options):
+    aggregate = options.get('aggregate', True)
+    if not aggregate:
+        return resp
+
+    numpat = 0
+    for node, node_numpat in resp.items():
+        numpat += node_numpat
+    return numpat
+
+
+def parse_pubsub_numsub(command, resp, **options):
+    aggregate = options.get('aggregate', True)
+    if not aggregate:
+        return resp
+
+    numsub_d = dict()
+    for _, numsub_tups in resp.items():
+        for channel, numsubbed in numsub_tups:
+            try:
+                numsub_d[channel] += numsubbed
+            except KeyError:
+                numsub_d[channel] = numsubbed
+
+    ret_numsub = []
+    for channel, numsub in numsub_d.items():
+        ret_numsub.append((channel, numsub))
+    return ret_numsub

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -205,36 +205,43 @@ def parse_cluster_nodes(resp, **options):
     return nodes
 
 
-def parse_pubsub_channels(command, resp, **options):
+def parse_pubsub_channels(command, res, **options):
+    """
+    Result callback, handles different return types
+    switchable by the `aggregate` flag.
+    """
     aggregate = options.get('aggregate', True)
     if not aggregate:
-        return resp
+        return res
+    return merge_result(command, res)
 
-    nodes = resp.keys()
-    channels = set()
-    for node in nodes:
-        channels.update(resp[node])
-    return sorted(list(channels))
-    
 
-def parse_pubsub_numpat(command, resp, **options):
+def parse_pubsub_numpat(command, res, **options):
+    """
+    Result callback, handles different return types
+    switchable by the `aggregate` flag.
+    """
     aggregate = options.get('aggregate', True)
     if not aggregate:
-        return resp
+        return res
 
     numpat = 0
-    for node, node_numpat in resp.items():
+    for node, node_numpat in res.items():
         numpat += node_numpat
     return numpat
 
 
-def parse_pubsub_numsub(command, resp, **options):
+def parse_pubsub_numsub(command, res, **options):
+    """
+    Result callback, handles different return types
+    switchable by the `aggregate` flag.
+    """
     aggregate = options.get('aggregate', True)
     if not aggregate:
-        return resp
+        return res
 
     numsub_d = dict()
-    for _, numsub_tups in resp.items():
+    for _, numsub_tups in res.items():
         for channel, numsubbed in numsub_tups:
             try:
                 numsub_d[channel] += numsubbed
@@ -245,3 +252,4 @@ def parse_pubsub_numsub(command, resp, **options):
     for channel, numsub in numsub_d.items():
         ret_numsub.append((channel, numsub))
     return ret_numsub
+

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -214,7 +214,7 @@ def parse_pubsub_channels(command, resp, **options):
     channels = set()
     for node in nodes:
         channels.update(resp[node])
-    return list(channels)
+    return sorted(list(channels))
     
 
 def parse_pubsub_numpat(command, resp, **options):

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -14,8 +14,9 @@ import pytest
 # import redis
 from redis import StrictRedis, Redis
 from redis.exceptions import ConnectionError
-from redis._compat import basestring, u, unichr
+from redis._compat import basestring, u, unichr, b
 
+from .conftest import skip_if_server_version_lt
 
 def wait_for_message(pubsub, timeout=0.5, ignore_subscribe_messages=False):
     now = time.time()
@@ -474,3 +475,31 @@ def test_pubsub_thread_publish():
             t.start()
     except Exception:
         print("Error: unable to start thread")
+
+
+class TestPubSubPubSubSubcommands(object):
+
+    @skip_if_server_version_lt('2.8.0')
+    def test_pubsub_channels(self, r):
+        p = r.pubsub(ignore_subscribe_messages=True)
+        p.subscribe('foo', 'bar', 'baz', 'quux')
+        channels = sorted(r.pubsub_channels())
+        assert channels == [b('bar'), b('baz'), b('foo'), b('quux')]
+
+    @skip_if_server_version_lt('2.8.0')
+    def test_pubsub_numsub(self, r):
+        p1 = r.pubsub(ignore_subscribe_messages=True)
+        p1.subscribe('foo', 'bar', 'baz')
+        p2 = r.pubsub(ignore_subscribe_messages=True)
+        p2.subscribe('bar', 'baz')
+        p3 = r.pubsub(ignore_subscribe_messages=True)
+        p3.subscribe('baz')
+
+        channels = [(b('foo'), 1), (b('bar'), 2), (b('baz'), 3)]
+        assert channels == r.pubsub_numsub('foo', 'bar', 'baz')
+
+    @skip_if_server_version_lt('2.8.0')
+    def test_pubsub_numpat(self, r):
+        p = r.pubsub(ignore_subscribe_messages=True)
+        p.psubscribe('*oo', '*ar', 'b*z')
+        assert r.pubsub_numpat() == 3

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -495,8 +495,8 @@ class TestPubSubPubSubSubcommands(object):
         p3 = r.pubsub(ignore_subscribe_messages=True)
         p3.subscribe('baz')
 
-        channels = [(b('foo'), 1), (b('bar'), 2), (b('baz'), 3)]
-        assert channels == r.pubsub_numsub('foo', 'bar', 'baz')
+        channels = [(b('bar'), 2), (b('baz'), 3), (b('foo'), 1)]
+        assert channels == sorted(r.pubsub_numsub('foo', 'bar', 'baz'))
 
     @skip_if_server_version_lt('2.8.0')
     def test_pubsub_numpat(self, r):

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -478,28 +478,28 @@ def test_pubsub_thread_publish():
 
 
 class TestPubSubPubSubSubcommands(object):
+    """
+    Test Pub/Sub subcommands of PUBSUB
+    @see https://redis.io/commands/pubsub
+    """
 
-    @skip_if_server_version_lt('2.8.0')
+    @skip_if_redis_py_version_lt('2.10.6')
     def test_pubsub_channels(self, r):
-        p = r.pubsub(ignore_subscribe_messages=True)
-        p.subscribe('foo', 'bar', 'baz', 'quux')
+        r.pubsub(ignore_subscribe_messages=True).subscribe('foo', 'bar', 'baz', 'quux')
         channels = sorted(r.pubsub_channels())
         assert channels == [b('bar'), b('baz'), b('foo'), b('quux')]
 
-    @skip_if_server_version_lt('2.8.0')
+    @skip_if_redis_py_version_lt('2.10.6')
     def test_pubsub_numsub(self, r):
-        p1 = r.pubsub(ignore_subscribe_messages=True)
-        p1.subscribe('foo', 'bar', 'baz')
-        p2 = r.pubsub(ignore_subscribe_messages=True)
-        p2.subscribe('bar', 'baz')
-        p3 = r.pubsub(ignore_subscribe_messages=True)
-        p3.subscribe('baz')
+        r.pubsub(ignore_subscribe_messages=True).subscribe('foo', 'bar', 'baz')
+        r.pubsub(ignore_subscribe_messages=True).subscribe('bar', 'baz')
+        r.pubsub(ignore_subscribe_messages=True).subscribe('baz')
 
         channels = [(b('bar'), 2), (b('baz'), 3), (b('foo'), 1)]
         assert channels == sorted(r.pubsub_numsub('foo', 'bar', 'baz'))
 
-    @skip_if_server_version_lt('2.8.0')
+    @skip_if_redis_py_version_lt('2.10.6')
     def test_pubsub_numpat(self, r):
-        p = r.pubsub(ignore_subscribe_messages=True)
-        p.psubscribe('*oo', '*ar', 'b*z')
+        r.pubsub(ignore_subscribe_messages=True).psubscribe('*oo', '*ar', 'b*z')
         assert r.pubsub_numpat() == 3
+

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -16,7 +16,7 @@ from redis import StrictRedis, Redis
 from redis.exceptions import ConnectionError
 from redis._compat import basestring, u, unichr, b
 
-from .conftest import skip_if_server_version_lt
+from .conftest import skip_if_server_version_lt, skip_if_redis_py_version_lt
 
 def wait_for_message(pubsub, timeout=0.5, ignore_subscribe_messages=False):
     now = time.time()


### PR DESCRIPTION
PUBSUB commands added to redis-py in commit [3f4ac6](https://github.com/andymccurdy/redis-py/commit/3f4ac6e685b122f49b516db3f59c1edc988e6b49), which should be sent to all nodes (https://redis.io/commands/pubsub, https://redis.io/topics/pubsub)