### PR TITLE
Add support keys that are already unicode encoded and for keys of other types

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -22,3 +22,5 @@ Authors who contributed code or testing:
  - monklof - https://github.com/monklof
  - dutradda - https://github.com/dutradda
  - AngusP - https://github.com/AngusP
+ - VascoVisser - https://github.com/VascoVisser
+

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -4,6 +4,7 @@ Release Notes
 Unstable
 --------
 
+    * Fixed issues with some key types in `NodeManager.keyslot()`.
     * Add support for `PUBSUB` subcommands `CHANNELS`, `NUMSUB [arg] [args...]` and `NUMPAT`.
     * Add method `set_result_callback(command, callback)` allowing the default reply callbacks to be changed, in the same way `set_response_callback(command, callback)` inherited from Redis-Py does for responses.
     * Node manager now honors defined max_connections variable so connections that is emited from that class uses the same variable.

--- a/rediscluster/crc.py
+++ b/rediscluster/crc.py
@@ -43,7 +43,7 @@ def _crc16_py3(data):
     """
     """
     crc = 0
-    for byte in data.encode("utf-8"):
+    for byte in data:
         crc = ((crc << 8) & 0xff00) ^ x_mode_m_crc16_lookup[((crc >> 8) & 0xff) ^ byte]
     return crc & 0xffff
 
@@ -52,7 +52,7 @@ def _crc16_py2(data):
     """
     """
     crc = 0
-    for byte in data.encode("utf-8"):
+    for byte in data:
         crc = ((crc << 8) & 0xff00) ^ x_mode_m_crc16_lookup[((crc >> 8) & 0xff) ^ ord(byte)]
     return crc & 0xffff
 

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -10,7 +10,7 @@ from .exceptions import RedisClusterException
 
 # 3rd party imports
 from redis import StrictRedis
-from redis._compat import unicode
+from redis._compat import b, unicode, bytes, long, basestring
 from redis import ConnectionError
 
 
@@ -37,45 +37,35 @@ class NodeManager(object):
         if not self.startup_nodes:
             raise RedisClusterException("No startup nodes provided")
 
-        # Minor performance tweak to avoid having to check inside the method
-        # for each call to keyslot method.
-        if sys.version_info[0] < 3:
-            self.keyslot = self.keyslot_py_2
-        else:
-            self.keyslot = self.keyslot_py_3
+    def encode(self, value):
+        """
+        Return a bytestring representation of the value.
+        This method is copied from Redis' connection.py:Connection.encode
+        """
+        if isinstance(value, bytes):
+            return value
+        elif isinstance(value, (int, long)):
+            value = b(str(value))
+        elif isinstance(value, float):
+            value = b(repr(value))
+        elif not isinstance(value, basestring):
+            value = unicode(value)
+        if isinstance(value, unicode):
+            # The encoding should be configurable as in connection.py:Connection.encode
+            value = value.encode('utf-8')
+        return value
 
-    def keyslot_py_2(self, key):
+    def keyslot(self, key):
         """
         Calculate keyslot for a given key.
         Tuned for compatibility with python 2.7.x
         """
-        k = unicode(key)
+        k = self.encode(key)
 
-        start = k.find("{")
-
-        if start > -1:
-            end = k.find("}", start + 1)
-            if end > -1 and end != start + 1:
-                k = k[start + 1:end]
-
-        return crc16(k) % self.RedisClusterHashSlots
-
-    def keyslot_py_3(self, key):
-        """
-        Calculate keyslot for a given key.
-        Tuned for compatibility with supported python 3.x versions
-        """
-        try:
-            # Handle bytes case
-            k = str(key, encoding='utf-8')
-        except TypeError:
-            # Convert others to str.
-            k = str(key)
-
-        start = k.find("{")
+        start = k.find(b"{")
 
         if start > -1:
-            end = k.find("}", start + 1)
+            end = k.find(b"}", start + 1)
             if end > -1 and end != start + 1:
                 k = k[start + 1:end]
 

--- a/tests/test_node_manager.py
+++ b/tests/test_node_manager.py
@@ -39,6 +39,13 @@ def test_keyslot():
     assert n.keyslot("{foo}bar") == 12182
     assert n.keyslot("{foo}") == 12182
     assert n.keyslot(1337) == 4314
+
+    assert n.keyslot(125) == n.keyslot(b"125")
+    assert n.keyslot(125) == n.keyslot("\x31\x32\x35")
+    assert n.keyslot("大奖") == n.keyslot(b"\xe5\xa4\xa7\xe5\xa5\x96")
+    assert n.keyslot(u"大奖") == n.keyslot(b"\xe5\xa4\xa7\xe5\xa5\x96")
+    assert n.keyslot(1337.1234) == n.keyslot("1337.1234")
+    assert n.keyslot(1337) == n.keyslot("1337")
     assert n.keyslot(b"abc") == n.keyslot("abc")
     assert n.keyslot("abc") == n.keyslot(unicode("abc"))
     assert n.keyslot(unicode("abc")) == n.keyslot(b"abc")


### PR DESCRIPTION
We bumped into a bug where an already encoded unicode string with unicode characters could not be processed by the keyslot function.

While fixing the bug we also added support for other key types such as float, int, long.

The PR include additions to the unit test for the keyslot function

There was another pull request (#170) that is overlapping, but that didn't cover all cases, had no unit test and was pending since beginning of December. This in PR includes the fix in #170.