### PR TITLE
fix StrictRedisCluster.from_url issue when skip_full_coverage_check p…

### DIFF
--- a/examples/from_url_password_protected.py
+++ b/examples/from_url_password_protected.py
@@ -1,0 +1,9 @@
+from rediscluster import StrictRedisCluster
+
+url="redis://:R1NFTBWTE1@10.127.91.90:6572/0"
+
+rc = StrictRedisCluster.from_url(url, skip_full_coverage_check=True)
+
+rc.set("foo", "bar")
+
+print(rc.get("foo"))

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -210,7 +210,7 @@ class StrictRedisCluster(StrictRedis):
         passed along to the ConnectionPool class's initializer. In the case
         of conflicting arguments, querystring arguments always win.
         """
-        connection_pool = ClusterConnectionPool.from_url(url, db=db, **kwargs)
+        connection_pool = ClusterConnectionPool.from_url(url, db=db, skip_full_coverage_check=skip_full_coverage_check,**kwargs)
         return cls(connection_pool=connection_pool, skip_full_coverage_check=skip_full_coverage_check)
 
     def __repr__(self):


### PR DESCRIPTION
The method( StrictRedisCluster.from_url) runs wrong when redis cluster does't support "CONFIG" command.

Detail info:

```
> Traceback (most recent call last):
>   File "from_url_password_protected.py", line 8, in <module>
>     rc = StrictRedisCluster.from_url(url, skip_full_coverage_check=True)
>   File "./rediscluster/client.py", line 214, in from_url
>     connection_pool = ClusterConnectionPool.from_url(url, db=db,**kwargs)
>   File "/usr/lib/python2.7/dist-packages/redis/connection.py", line 844, in from_url
>     return cls(**kwargs)
>   File "./rediscluster/connection.py", line 141, in __init__
>     self.nodes.initialize()
>   File "./rediscluster/nodemanager.py", line 228, in initialize
>     need_full_slots_coverage = self.cluster_require_full_coverage(nodes_cache)
>   File "./rediscluster/nodemanager.py", line 270, in cluster_require_full_coverage
>     return any(node_require_full_coverage(node) for node in nodes.values())
>   File "./rediscluster/nodemanager.py", line 270, in <genexpr>
>     return any(node_require_full_coverage(node) for node in nodes.values())
>   File "./rediscluster/nodemanager.py", line 267, in node_require_full_coverage
>     return "yes" in r_node.config_get("cluster-require-full-coverage").values()
>   File "/usr/lib/python2.7/dist-packages/redis/client.py", line 620, in config_get
>     return self.execute_command('CONFIG GET', pattern)
>   File "/usr/lib/python2.7/dist-packages/redis/client.py", line 573, in execute_command
>     return self.parse_response(connection, command_name, **options)
>   File "/usr/lib/python2.7/dist-packages/redis/client.py", line 585, in parse_response
>     response = connection.read_response()
>   File "/usr/lib/python2.7/dist-packages/redis/connection.py", line 582, in read_response
>     raise response
> redis.exceptions.ResponseError: unknown command 'CONFIG'
> 
```