### PR TITLE
Add missing interactive shell for redis cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Small sample script that shows how to get started with RedisCluster. It can also
 True
 >>> print(rc.get("foo"))
 'bar'
+
+You can also achieve this by using the interactive shell
+>>> redishost:~# redis-clu
+
+>>> redishost:7000> set foo bar
+>>> True
+
+>>> redishost:7000> get foo
+>>> 'bar'
 ```
 
 

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -25,3 +25,4 @@ Authors who contributed code or testing:
  - Doug Kent - https://github.com/dkent
  - VascoVisser - https://github.com/VascoVisser
  - astrohsy - https://github.com/astrohsy
+ - Lacunoc - https://github.com/lacunoc

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+Next release
+-------------------
+    * Add interactive shell for redis cluster (redis-clu)
+
 1.3.4 (Mar 5, 2017)
 -------------------
 
@@ -79,7 +83,7 @@ Release Notes
     * Implement all "CLUSTER ..." commands as methods in the client class
     * Client now follows the service side setting 'cluster-require-full-coverage=yes/no' (baranbartu)
     * Change the pubsub implementation (PUBLISH/SUBSCRIBE commands) from using one single node to now determine the hashslot for the channel name and use that to connect to
-      a node in the cluster. Other clients that do not use this pattern will not be fully compatible with this client. Known limitations is pattern 
+      a node in the cluster. Other clients that do not use this pattern will not be fully compatible with this client. Known limitations is pattern
       subscription that do not work properly because a pattern can't know all the possible channel names in advance.
     * Convert all docs to ReadTheDocs
     * Rework connection pool logic to be more similar to redis-py. This also fixes an issue with pubsub and that connections

--- a/rediscluster/clu.py
+++ b/rediscluster/clu.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+"""
+redis cluster command line interface
+"""
+
+import re
+import socket
+from argparse import ArgumentParser
+from rediscluster import StrictRedisCluster
+from pprint import pprint
+
+
+def get_parser():
+    """Get argument parser -> ArgumentParser"""
+
+    parser = ArgumentParser()
+
+    parser.add_argument(
+        '--node', '-n', help='hostname of any cluster node',
+        default='127.0.0.1'
+    )
+    parser.add_argument(
+        '--pw', '-a', help='pw to auth, same as for redis-cli'
+    )
+    parser.add_argument(
+        '--port', '-p', help='port where redis is running', default=7000
+    )
+
+    return parser
+
+
+def get_redis_config():
+    """Get password and port from local installed redis instance
+
+    These credentials are used, when no values are passed to the
+    ArgumentParser
+    """
+
+    with open('/etc/redis/redis.conf', 'r') as config_file:
+        for line in config_file:
+            if re.match('^requirepass(.*)', line):
+                password = line.split()[1]
+            if re.match('^port(.*)', line):
+                port = line.split()[1]
+    return port, password
+
+
+def main():
+    args = get_parser().parse_args()
+
+    port, password = get_redis_config()
+
+    if port:
+        args.port = port
+    if password:
+        args.pw = password
+
+    startup_nodes = [{
+        'host': args.node,
+        'port': args.port
+    }]
+
+    rc = StrictRedisCluster(
+        startup_nodes=startup_nodes,
+        decode_responses=True,
+        password=args.pw
+    )
+
+    while True:
+        cmd_input = input(socket.gethostname() + ':' + args.port + '> ')
+        if len(cmd_input) > 0:
+            cmd = cmd_input.split()[0]
+            cmd_args = cmd_input.split()[1:]
+
+            if cmd in ('quit', 'exit'):
+                raise SystemExit
+            elif cmd == '?':
+                for supported_command in sorted(dir(rc)):
+                    if not supported_command.startswith("_"):
+                        pprint(supported_command)
+            else:
+                if hasattr(rc, cmd):
+                    method_to_call = getattr(rc, cmd)
+                    pprint(method_to_call(*cmd_args))
+                else:
+                    pprint('The command ' + cmd + ' is not implemented')
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import os
 
 try:
-    from setuptools import setup
+    from setuptools import setup, find_packages
 except ImportError:
     from distutils.core import setup
 
@@ -27,7 +27,7 @@ setup(
     author_email="Grokzen@gmail.com",
     maintainer='Johan Andersson',
     maintainer_email='Grokzen@gmail.com',
-    packages=["rediscluster"],
+    packages=find_packages(),
     url='http://github.com/grokzen/redis-py-cluster',
     license='MIT',
     install_requires=[
@@ -37,6 +37,11 @@ setup(
         'redis',
         'redis cluster',
     ],
+    entry_points={
+        'console_scripts': [
+            'redis-clu=rediscluster.clu:main'
+        ],
+    },
     classifiers=(
         # As from https://pypi.python.org/pypi?%3Aaction=list_classifiers
         # 'Development Status :: 1 - Planning',

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,0 +1,2 @@
+[DEFAULT]
+Depends3: python3-setuptools, python3-pkg-resources


### PR DESCRIPTION
Due to the fact, that a interactive shell is still missing for redis clusters, I gave it a try and wrote this small script to make use of your existing and working client.

Here is an basic example (executed on a redis cluster with 6 instances / 3xMaster + 3xSlave)

```
> redishost:~# redis-clu
```
```
> redishost:7000> keys *
> []
```
```
> redishost:7000> set foo bar
> True
```
```
> redishost:7000> keys *
> ['foo']
```
```
> redishost:7000> get foo
> 'bar'
```
```
> redishost:7000> ?
> 'CLUSTER_COMMANDS_RESPONSE_CALLBACKS'
> 'NODES_FLAGS'
> 'RESPONSE_CALLBACKS'
> 'RESULT_CALLBACKS'
> 'RedisClusterRequestTTL'
> 'append'
> 'bgrewriteaof'
> 'bgsave'
> 'bitcount'
> 'bitop'
> 'bitpos'
> 'blpop'
> 'brpop'
> 'brpoplpush'
> 'client_getname'
> 'client_kill'
> 'client_list'
> 'client_setname'
> 'cluster_addslots'
> 'cluster_count_failure_report'
> 'cluster_countkeysinslot'
> 'cluster_delslots'
> 'cluster_failover'
> 'cluster_info'
> 'cluster_keyslot'
> 'cluster_meet'
> 'cluster_nodes'
> 'cluster_replicate'
> 'cluster_reset'
> 'cluster_reset_all_nodes'
> 'cluster_save_config'
> 'cluster_set_config_epoch'
> 'cluster_setslot'
> 'cluster_slaves'
> 'cluster_slots'
> 'config_get'
> 'config_resetstat'
> 'config_rewrite'
> 'config_set'
> 'connection_pool'
> 'dbsize'
> 'debug_object'
> 'decr'
> 'delete'
> 'determine_node'
> 'dump'
> 'echo'
> 'eval'
> 'evalsha'
> 'execute_command'
> 'exists'
> 'expire'
> 'expireat'
> 'flushall'
> 'flushdb'
> 'from_url'
> 'get'
> 'getbit'
> 'getrange'
> 'getset'
> 'hdel'
> 'hexists'
> 'hget'
> 'hgetall'
> 'hincrby'
> 'hincrbyfloat'
> 'hkeys'
> 'hlen'
> 'hmget'
> 'hmset'
> 'hscan'
> 'hscan_iter'
> 'hset'
> 'hsetnx'
> 'hvals'
> 'incr'
> 'incrby'
> 'incrbyfloat'
> 'info'
> 'keys'
> 'lastsave'
> 'lindex'
> 'linsert'
> 'llen'
> 'lock'
> 'lpop'
> 'lpush'
> 'lpushx'
> 'lrange'
> 'lrem'
> 'lset'
> 'ltrim'
> 'mget'
> 'move'
> 'mset'
> 'msetnx'
> 'nodes_flags'
> 'object'
> 'parse_response'
> 'persist'
> 'pexpire'
> 'pexpireat'
> 'pfadd'
> 'pfcount'
> 'pfmerge'
> 'ping'
> 'pipeline'
> 'psetex'
> 'pttl'
> 'publish'
> 'pubsub'
> 'pubsub_channels'
> 'pubsub_numpat'
> 'pubsub_numsub'
> 'randomkey'
> 'refresh_table_asap'
> 'register_script'
> 'rename'
> 'renamenx'
> 'response_callbacks'
> 'restore'
> 'result_callbacks'
> 'rpop'
> 'rpoplpush'
> 'rpush'
> 'rpushx'
> 'sadd'
> 'save'
> 'scan'
> 'scan_iter'
> 'scard'
> 'script_exists'
> 'script_flush'
> 'script_kill'
> 'script_load'
> 'sdiff'
> 'sdiffstore'
> 'sentinel'
> 'sentinel_get_master_addr_by_name'
> 'sentinel_master'
> 'sentinel_masters'
> 'sentinel_monitor'
> 'sentinel_remove'
> 'sentinel_sentinels'
> 'sentinel_set'
> 'sentinel_slaves'
> 'set'
> 'set_response_callback'
> 'set_result_callback'
> 'setbit'
> 'setex'
> 'setnx'
> 'setrange'
> 'shutdown'
> 'sinter'
> 'sinterstore'
> 'sismember'
> 'slaveof'
> 'slowlog_get'
> 'slowlog_len'
> 'slowlog_reset'
> 'smembers'
> 'smove'
> 'sort'
> 'spop'
> 'srandmember'
> 'srem'
> 'sscan'
> 'sscan_iter'
> 'strlen'
> 'substr'
> 'sunion'
> 'sunionstore'
> 'time'
> 'transaction'
> 'ttl'
> 'type'
> 'unwatch'
> 'wait'
> 'watch'
> 'zadd'
> 'zcard'
> 'zcount'
> 'zincrby'
> 'zinterstore'
> 'zlexcount'
> 'zrange'
> 'zrangebylex'
> 'zrangebyscore'
> 'zrank'
> 'zrem'
> 'zremrangebylex'
> 'zremrangebyrank'
> 'zremrangebyscore'
> 'zrevrange'
> 'zrevrangebylex'
> 'zrevrangebyscore'
> 'zrevrank'
> 'zscan'
> 'zscan_iter'
> 'zscore'
> 'zunionstore'
```
```
> redishost:7000> quit
```