### PR TITLE
Add watch, unwatch, mul method to pipeline

### DIFF
--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -201,6 +201,9 @@ class StrictClusterPipeline(StrictRedisCluster):
             if n.connection in self.connection_pool._available_connections.get(node_name, []):
                 self.connection_pool._available_connections[node_name].remove(n.connection)
 
+            if self.connection_pool._created_connections_per_node.get(node_name, 0):
+                self.connection_pool._created_connections_per_node[node_name] -= 1
+
         # if the response isn't an exception it is a valid response from the node
         # we're all done with that command, YAY!
         # if we have more commands to attempt, we've run into problems.

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -253,3 +253,13 @@ def parse_pubsub_numsub(command, res, **options):
     for channel, numsub in numsub_d.items():
         ret_numsub.append((channel, numsub))
     return ret_numsub
+
+
+def parse_del(response, *args, **kwargs):
+
+    s = '{}'.format(response)
+
+    if s.isdigit():
+        return int(s)
+    else:
+        return s


### PR DESCRIPTION
    Add watch, unwatch, mul method to pipeline

    Use transaction with pipeline in redis cluster

    Do the operation with keys with same prefix, so that command will be
    executed on the same node

    * Reference pipeline function

    Signed-off-by: Lei Gong <xue177125184@gmail.com>