### PR TITLE
Update client.py

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -373,7 +373,6 @@ class StrictRedisCluster(StrictRedis):
                 # This counter will increase faster when the same client object
                 # is shared between multiple threads. To reduce the frequency you
                 # can set the variable 'reinitialize_steps' in the constructor.
-                self.refresh_table_asap = True
                 self.connection_pool.nodes.increment_reinitialize_counter()
 
                 node = self.connection_pool.nodes.set_node(e.host, e.port, server_type='master')


### PR DESCRIPTION
 if set refresh_table_asap after initialised then  it will case many connection_pool.nodes.initialize() as the client is shared between multiple threads (the shared param refresh_table_asap is seted to false after nodes.initialize()) ，cause machine memory exhausted. And when a slot MovedError, it not need  to initialize all the node.