### PR TITLE
Set all error results in NodeCommands

### DIFF
--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -430,6 +430,6 @@ class NodeCommands(object):
                 except (ConnectionError, TimeoutError) as e:
                     for c in self.commands:
                         c.result = e
-                        return
+                    return
                 except RedisError:
                     c.result = sys.exc_info()[1]


### PR DESCRIPTION
Previously, there was a return from within a loop, preventing the other
command results from being set to the same error, and in turn preventing
those commands from being retried.