### PR TITLE
Fix #217

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+Future Release
+--------------
+
+    * Add Redis 4 compatability fix to CLUSTER NODES command (See issue #217)
+
 1.3.4 (Mar 5, 2017)
 -------------------
 

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -182,12 +182,14 @@ def parse_cluster_nodes(resp, **options):
         self_id, addr, flags, master_id, ping_sent, \
             pong_recv, config_epoch, link_state = parts[:8]
 
-        host, port = addr.rsplit(':', 1)
+        host, ports = addr.rsplit(':', 1)
+        port, _, cluster_port = ports.partition('@')
 
         node = {
             'id': self_id,
             'host': host or current_host,
             'port': int(port),
+            'cluster-bus-port': int(cluster_port) if cluster_port else 10000 + int(port),
             'flags': tuple(flags.split(',')),
             'master': master_id if master_id != '-' else None,
             'ping-sent': int(ping_sent),


### PR DESCRIPTION
Adds `cluster-bus-port` to each node's dict for both >=4.0 nodes and <4.0 to keep consistency