### PR TITLE
Fix retries for connection errors in pipelines

### DIFF
--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -430,6 +430,6 @@ class NodeCommands(object):
                 except (ConnectionError, TimeoutError) as e:
                     for c in self.commands:
                         c.result = e
-                        return
+                    return
                 except RedisError:
                     c.result = sys.exc_info()[1]


### PR DESCRIPTION
Fix retries for connection errors in pipelines

When a connection or timeout error is received
when reading out the responses from a redis node
during a pipelined command, all of the commands
from that node need to be marked for retry.

The code was already written to handle this case,
but due to a small oversight in scoping there is
an early return on the first iteration of the loop
that causes all but the first command in the pipeline
for each node not to be marked for retry.