### PR TITLE
Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Environment :: Web Environment',
         'Operating System :: POSIX',
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'redis',
         'redis cluster',
     ],
-    classifiers=(
+    classifiers=[
         # As from https://pypi.python.org/pypi?%3Aaction=list_classifiers
         # 'Development Status :: 1 - Planning',
         # 'Development Status :: 2 - Pre-Alpha',
@@ -57,5 +57,5 @@ setup(
         'Environment :: Web Environment',
         'Operating System :: POSIX',
         'License :: OSI Approved :: MIT License',
-    )
+    ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35, hi27, hi33, hi34, hi35, flake8-py34, flake8-py27
+envlist = py27, py33, py34, py35, py36, hi27, hi33, hi34, hi35, flake8-py34, flake8-py27
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt


### PR DESCRIPTION
From Travis it seems that redis-py-cluster already support Python 3.6. I just added a new environment in `tox`, as well as a new Trove classifier. Also I had to use a list for the classifiers, since they don't appear on PyPi if they are not a list.