### PR TITLE
Support passing a specific connection class to StrictRedisCluster 

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -126,7 +126,8 @@ class StrictRedisCluster(StrictRedis):
     }
 
     def __init__(self, host=None, port=None, startup_nodes=None, max_connections=32, max_connections_per_node=False, init_slot_cache=True,
-                 readonly_mode=False, reinitialize_steps=None, skip_full_coverage_check=False, nodemanager_follow_cluster=False, **kwargs):
+                 readonly_mode=False, reinitialize_steps=None, skip_full_coverage_check=False, nodemanager_follow_cluster=False,
+                 connection_class=None, **kwargs):
         """
         :startup_nodes:
             List of nodes that initial bootstrapping can be done from
@@ -178,6 +179,7 @@ class StrictRedisCluster(StrictRedis):
                 max_connections_per_node=max_connections_per_node,
                 skip_full_coverage_check=skip_full_coverage_check,
                 nodemanager_follow_cluster=nodemanager_follow_cluster,
+                connection_class=connection_class,
                 **kwargs
             )
 

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -98,7 +98,7 @@ class ClusterConnectionPool(ConnectionPool):
     """
     RedisClusterDefaultTimeout = None
 
-    def __init__(self, startup_nodes=None, init_slot_cache=True, connection_class=ClusterConnection,
+    def __init__(self, startup_nodes=None, init_slot_cache=True, connection_class=None,
                  max_connections=None, max_connections_per_node=False, reinitialize_steps=None,
                  skip_full_coverage_check=False, nodemanager_follow_cluster=False, **connection_kwargs):
         """
@@ -110,6 +110,8 @@ class ClusterConnectionPool(ConnectionPool):
             it was operating on. This will allow the client to drift along side the cluster
             if the cluster nodes move around alot.
         """
+        if connection_class is None:
+            connection_class = ClusterConnection
         super(ClusterConnectionPool, self).__init__(connection_class=connection_class, max_connections=max_connections)
 
         # Special case to make from_url method compliant with cluster setting.
@@ -339,10 +341,12 @@ class ClusterReadOnlyConnectionPool(ClusterConnectionPool):
     Readonly connection pool for rediscluster
     """
 
-    def __init__(self, startup_nodes=None, init_slot_cache=True, connection_class=ClusterConnection,
+    def __init__(self, startup_nodes=None, init_slot_cache=True, connection_class=None,
                  max_connections=None, nodemanager_follow_cluster=False, **connection_kwargs):
         """
         """
+        if connection_class is None:
+            connection_class = ClusterConnection
         super(ClusterReadOnlyConnectionPool, self).__init__(
             startup_nodes=startup_nodes,
             init_slot_cache=init_slot_cache,


### PR DESCRIPTION
This cannot be done by using kwargs because kwargs are later passed on to the super init(which is StrictRedis) and it doesn't support arbitrary kwargs, so it fails when trying to pass connection_class as named argument to StrictRedis constructor.

StrictRedis constructor:
` 
def __init__(self, host='localhost', port=6379,
                 db=0, password=None, socket_timeout=None,
                 socket_connect_timeout=None,
                 socket_keepalive=None, socket_keepalive_options=None,
                 connection_pool=None, unix_socket_path=None,
                 encoding='utf-8', encoding_errors='strict',
                 charset=None, errors=None,
                 decode_responses=False, retry_on_timeout=False,
                 ssl=False, ssl_keyfile=None, ssl_certfile=None,
                 ssl_cert_reqs=None, ssl_ca_certs=None,
                 max_connections=None):
`

This doesn't break any interface.
I need this to use SSL connection class with my cluster connection.