### PR TITLE
Remove the magic value 'max_connections=32'

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -125,7 +125,7 @@ class StrictRedisCluster(StrictRedis):
         'READWRITE': bool_ok,
     }
 
-    def __init__(self, host=None, port=None, startup_nodes=None, max_connections=32, max_connections_per_node=False, init_slot_cache=True,
+    def __init__(self, host=None, port=None, startup_nodes=None, max_connections=None, max_connections_per_node=False, init_slot_cache=True,
                  readonly_mode=False, reinitialize_steps=None, skip_full_coverage_check=False, nodemanager_follow_cluster=False,
                  connection_class=None, **kwargs):
         """


### PR DESCRIPTION
Remove the magic value 'max_connections=32' in client.py,using None as default.
If we do not set 'max_connections', it is easy to throw out the exception "Too many connections".