### PR TITLE
Refresh node table when executing commands on specific nodes

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -26,3 +26,4 @@ Authors who contributed code or testing:
  - VascoVisser - https://github.com/VascoVisser
  - astrohsy - https://github.com/astrohsy
  - Artur Stawiarski - https://github.com/astawiarski
+ - Matthew Anderson - https://github.com/mc3ander

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -8,6 +8,8 @@ Future Release
     * Fixed bug with command "CLUSTER GETKEYSINSLOT" that was throwing exceptions
     * Added new methods cluster_get_keys_in_slot() to client
     * Fixed bug with `StrictRedisCluster.from_url` that was ignoring the `readonly_mode` parameter
+    * NodeManager will now ignore nodes showing cluster errors when initializing the cluster
+    * Fix bug where RedisCluster wouldn't refresh the cluster table when executing commands on specific nodes
 
 1.3.4 (Mar 5, 2017)
 -------------------

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -321,14 +321,14 @@ class StrictRedisCluster(StrictRedis):
 
         command = args[0]
 
-        node = self.determine_node(*args, **kwargs)
-        if node:
-            return self._execute_command_on_nodes(node, *args, **kwargs)
-
         # If set externally we must update it before calling any commands
         if self.refresh_table_asap:
             self.connection_pool.nodes.initialize()
             self.refresh_table_asap = False
+
+        node = self.determine_node(*args, **kwargs)
+        if node:
+            return self._execute_command_on_nodes(node, *args, **kwargs)
 
         redirect_addr = None
         asking = False
@@ -416,6 +416,12 @@ class StrictRedisCluster(StrictRedis):
 
                 connection.send_command(*args)
                 res[node["name"]] = self.parse_response(connection, command, **kwargs)
+            except ClusterDownError as e:
+                self.connection_pool.disconnect()
+                self.connection_pool.reset()
+                self.refresh_table_asap = True
+
+                raise
             finally:
                 self.connection_pool.release(connection)
 

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -342,7 +342,7 @@ class StrictRedisCluster(StrictRedis):
 
             if asking:
                 node = self.connection_pool.nodes.nodes[redirect_addr]
-                r = self.connection_pool.get_connection_by_node(node, command)
+                r = self.connection_pool.get_connection_by_node(node)
             elif try_random_node:
                 r = self.connection_pool.get_random_connection()
                 try_random_node = False

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -32,6 +32,7 @@ class ClusterParser(DefaultParser):
             'MOVED': MovedError,
             'CLUSTERDOWN': ClusterDownError,
             'CROSSSLOT': ClusterCrossSlotError,
+            'MASTERDOWN': MasterDownError,
         })
 
 

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -12,6 +12,7 @@ from .nodemanager import NodeManager
 from .exceptions import (
     RedisClusterException, AskError, MovedError,
     TryAgainError, ClusterDownError, ClusterCrossSlotError,
+    MasterDownError,
 )
 
 # 3rd party imports

--- a/rediscluster/exceptions.py
+++ b/rediscluster/exceptions.py
@@ -74,3 +74,8 @@ class MovedError(AskError):
     """
     """
     pass
+
+class MasterDownError(ClusterDownError):
+    """
+    """
+    pass

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -10,7 +10,7 @@ from .exceptions import RedisClusterException
 # 3rd party imports
 from redis import StrictRedis
 from redis._compat import b, unicode, bytes, long, basestring
-from redis import ConnectionError
+from redis import ConnectionError, ResponseError
 
 
 class NodeManager(object):
@@ -154,10 +154,6 @@ class NodeManager(object):
     def initialize(self):
         """
         Init the slots cache by asking all startup nodes what the current cluster configuration is
-
-        TODO: Currently the last node will have the last say about how the configuration is setup.
-        Maybe it should stop to try after it have correctly covered all slots or when one node is reached
-        and it could execute CLUSTER SLOTS command.
         """
         nodes_cache = {}
         tmp_slots = {}
@@ -179,6 +175,12 @@ class NodeManager(object):
                 startup_nodes_reachable = True
             except ConnectionError:
                 continue
+            except ResponseError as e:
+                # Isn't a cluster connection, so it won't parse these exceptions automatically
+                if 'CLUSTERDOWN' in e.message or 'MASTERDOWN' in e.message:
+                    continue
+                else:
+                    raise RedisClusterException("ERROR sending 'cluster slots' command to redis server: {0}".format(node))
             except Exception:
                 raise RedisClusterException("ERROR sending 'cluster slots' command to redis server: {0}".format(node))
 

--- a/tests/test_cluster_connection_pool.py
+++ b/tests/test_cluster_connection_pool.py
@@ -243,7 +243,7 @@ class TestReadOnlyConnectionPool(object):
         """
         pool = self.get_pool(connection_kwargs={})
 
-        expected_ports = {7000, 7005}
+        expected_ports = {7000, 7003}
         actual_ports = set()
         for _ in range(0, 100):
             node = pool.get_node_by_slot_random(0)


### PR DESCRIPTION
If the cluster state changes before executing a command that operates on a specific set of nodes (like ping or eval) the client will just retry on the same set of nodes until the clusterdown_wrapper reraises the error. This PR just adds the behaviour from `execute_command` to `_execute_command_on_nodes`. It also changes NodeManager to handle ClusterDown and MasterDown the same way it already handles connection errors, so that it can still initialize a cluster in the case of downed nodes.