### PR TITLE
Recover from primary failures when socket_timeout is > 0

### DIFF
--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -10,7 +10,7 @@ from .exceptions import RedisClusterException
 # 3rd party imports
 from redis import StrictRedis
 from redis._compat import b, unicode, bytes, long, basestring
-from redis import ConnectionError
+from redis import ConnectionError, TimeoutError
 
 
 class NodeManager(object):
@@ -177,7 +177,7 @@ class NodeManager(object):
                 r = self.get_redis_link(host=node["host"], port=node["port"], decode_responses=True)
                 cluster_slots = r.execute_command("cluster", "slots")
                 startup_nodes_reachable = True
-            except ConnectionError:
+            except (ConnectionError, TimeoutError):
                 continue
             except Exception:
                 raise RedisClusterException("ERROR sending 'cluster slots' command to redis server: {0}".format(node))


### PR DESCRIPTION
When the primary node is down and `socket_timeout` is > 0 rediscluster throws `RedisClusterException` instead of trying to retrieve cluster slots from other nodes. 
