### PR TITLE
Read replica support for single commands

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -380,8 +380,6 @@ class StrictRedisCluster(StrictRedis):
                 else:
                     node = self.connection_pool.get_node_by_slot(slot, self.read_from_replicas and (command in self.READ_COMMANDS))
                     is_read_replica = node['server_type'] == 'slave'
-                    print "node:", node
-
                 r = self.connection_pool.get_connection_by_node(node)
 
             try:

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -74,7 +74,7 @@ class StrictRedisCluster(StrictRedis):
 
     # Not complete, but covers the major ones
     # https://redis.io/commands
-    READ_COMMANDS = Set(["BITPOS", "BITCOUNT", "EXISTS",
+    READ_COMMANDS = ["BITPOS", "BITCOUNT", "EXISTS",
         "GEOHASH", "GEOPOS", "GEODIST", "GEORADIUS", "GEORADIUSBYMEMBER",
         "GET", "GETBIT", "GETRANGE",
         "HEXISTS", "HGET", "HGETALL", "HKEYS", "HLEN", "HMGET", "HSTRLEN", "HVALS",
@@ -84,7 +84,7 @@ class StrictRedisCluster(StrictRedis):
         "SCARD", "SDIFF", "SINTER", "SISMEMBER", "SMEMBERS", "SRANDMEMBER",
         "STRLEN", "SUNION", "TTL",
         "ZCARD", "ZCOUNT", "ZRANGE", "ZSCORE"
-    ])
+    ]
 
     RESULT_CALLBACKS = dict_merge(
         string_keys_to_dict([
@@ -146,7 +146,7 @@ class StrictRedisCluster(StrictRedis):
 
     def __init__(self, host=None, port=None, startup_nodes=None, max_connections=None, max_connections_per_node=False, init_slot_cache=True,
                  readonly_mode=False, reinitialize_steps=None, skip_full_coverage_check=False, nodemanager_follow_cluster=False,
-                 connection_class=None, enable_read_from_replicas=False, **kwargs):
+                 connection_class=None, read_from_replicas=False, **kwargs):
         """
         :startup_nodes:
             List of nodes that initial bootstrapping can be done from
@@ -212,7 +212,7 @@ class StrictRedisCluster(StrictRedis):
         self.result_callbacks = self.__class__.RESULT_CALLBACKS.copy()
         self.response_callbacks = self.__class__.RESPONSE_CALLBACKS.copy()
         self.response_callbacks = dict_merge(self.response_callbacks, self.CLUSTER_COMMANDS_RESPONSE_CALLBACKS)
-        self.enable_read_from_replicas = enable_read_from_replicas
+        self.read_from_replicas = read_from_replicas
 
     @classmethod
     def from_url(cls, url, db=None, skip_full_coverage_check=False, readonly_mode=False, **kwargs):
@@ -375,7 +375,7 @@ class StrictRedisCluster(StrictRedis):
                     # MOVED
                     node = self.connection_pool.get_master_node_by_slot(slot)
                 else:
-                    node, is_read_replica = self.connection_pool.get_node_by_slot(slot, self.enable_read_from_replicas and (command in self.READ_COMMANDS))
+                    node, is_read_replica = self.connection_pool.get_node_by_slot(slot, self.read_from_replicas and (command in self.READ_COMMANDS))
                 r = self.connection_pool.get_connection_by_node(node)
 
             try:

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -342,10 +342,10 @@ class ClusterConnectionPool(ConnectionPool):
         is_read_replica = random_index > 0
         return nodes_in_slot[random_index], is_read_replica
 
-    def get_node_by_slot(self, slot, enable_read_from_replicas):
+    def get_node_by_slot(self, slot, read_from_replicas):
         """
         """
-        if enable_read_from_replicas:
+        if read_from_replicas:
             return self.get_random_node_by_slot(slot)
         else:
             return self.get_master_node_by_slot(slot), False

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -307,7 +307,7 @@ class ClusterConnectionPool(ConnectionPool):
         self._checkpid()
 
         try:
-            return self.get_master_node_by_slot()
+            return self.get_master_connection_by_slot()
         except KeyError:
             return self.get_random_connection()
 

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -408,15 +408,12 @@ class ClusterWithReadReplicasConnectionPool(ClusterConnectionPool):
         """
         Get a random node from the slot, including master
         """
-        print "Choosing slot from:", self.nodes.slots[slot], "with reads on:", read_command
         nodes_in_slot = self.nodes.slots[slot]
-
         if read_command:
             random_index = random.randrange(0, len(nodes_in_slot))
-            is_read_replica = random_index > 0
-            return nodes_in_slot[random_index], is_read_replica
+            return nodes_in_slot[random_index]
         else:
-            return nodes_in_slot[0], False
+            return nodes_in_slot[0]
 
 
 @contextmanager

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -307,8 +307,7 @@ class ClusterConnectionPool(ConnectionPool):
         self._checkpid()
 
         try:
-            node, is_read_replica = self.get_node_by_slot(slot)
-            return self.get_connection_by_node()
+            return self.get_master_node_by_slot()
         except KeyError:
             return self.get_random_connection()
 

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -282,6 +282,9 @@ class NodeManager(object):
 
         # TODO: This shold not be constructed this way. It should update the name of the node in the node cache dict
         """
+
+        print "set_node_name n:", n
+
         if "name" not in n:
             n["name"] = "{0}:{1}".format(n["host"], n["port"])
 

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -282,9 +282,6 @@ class NodeManager(object):
 
         # TODO: This shold not be constructed this way. It should update the name of the node in the node cache dict
         """
-
-        print "set_node_name n:", n
-
         if "name" not in n:
             n["name"] = "{0}:{1}".format(n["host"], n["port"])
 

--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -155,7 +155,7 @@ class StrictClusterPipeline(StrictRedisCluster):
             # refer to our internal node -> slot table that tells us where a given
             # command should route to.
             slot = self._determine_slot(*c.args)
-            node = self.connection_pool.get_node_by_slot(slot)
+            node = self.connection_pool.get_node_by_slot(slot, False)
 
             # little hack to make sure the node name is populated. probably could clean this up.
             self.connection_pool.nodes.set_node_name(node)

--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -155,7 +155,7 @@ class StrictClusterPipeline(StrictRedisCluster):
             # refer to our internal node -> slot table that tells us where a given
             # command should route to.
             slot = self._determine_slot(*c.args)
-            node = self.connection_pool.get_node_by_slot(slot, False)
+            node = self.connection_pool.get_node_by_slot(slot)
 
             # little hack to make sure the node name is populated. probably could clean this up.
             self.connection_pool.nodes.set_node_name(node)

--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -24,7 +24,7 @@ class StrictClusterPipeline(StrictRedisCluster):
     """
 
     def __init__(self, connection_pool, result_callbacks=None,
-                 response_callbacks=None, startup_nodes=None):
+                 response_callbacks=None, startup_nodes=None, read_from_replicas=False):
         """
         """
         self.command_stack = []
@@ -32,6 +32,7 @@ class StrictClusterPipeline(StrictRedisCluster):
         self.connection_pool = connection_pool
         self.result_callbacks = result_callbacks or self.__class__.RESULT_CALLBACKS.copy()
         self.startup_nodes = startup_nodes if startup_nodes else []
+        self.read_from_replicas = read_from_replicas
         self.nodes_flags = self.__class__.NODES_FLAGS.copy()
         self.response_callbacks = dict_merge(response_callbacks or self.__class__.RESPONSE_CALLBACKS.copy(),
                                              self.CLUSTER_COMMANDS_RESPONSE_CALLBACKS)


### PR DESCRIPTION
This is a sketch of how I could see implementing support for spreading reads across an entire shard with Redis Cluster. I tested this with a cluster and observed a uniform distribution of requests across each shard.

- Each time `execute_command` is called for a read replica, the `READONLY` command is sent.
- I'm not sure how connection pooling and `READONLY` and `READWRITE` interact. Per my testing, `READONLY` is only active for the duration of the connection, so I think it always needs to be sent before executing a read command there is a guaranteed read connection pool that always sends this command on initialization.
- No support for pipelines for sake of simplicity
- No tests

Is this a gross oversimplification of what you were thinking with respect to this issue?