### PR TITLE
fix issue when having ssl=False causing unexpected keyword argument

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -161,7 +161,7 @@ class StrictRedisCluster(StrictRedis):
         if "db" in kwargs:
             raise RedisClusterException("Argument 'db' is not possible to use in cluster mode")
 
-        if kwargs.get('ssl', False):
+        if kwargs.pop('ssl', False):  # Needs to be removed to avoid exception in redis Connection init
             connection_class = SSLClusterConnection
 
         if "connection_pool" in kwargs:

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -71,7 +71,6 @@ class SSLClusterConnection(SSLConnection):
     def __init__(self, **kwargs):
         self.readonly = kwargs.pop('readonly', False)
         kwargs['parser_class'] = ClusterParser
-        kwargs.pop('ssl', None)  # Needs to be removed to avoid exception in redis Connection init
         super(SSLClusterConnection, self).__init__(**kwargs)
 
     def on_connect(self):


### PR DESCRIPTION
When I set `ssl=False` explicitly, eg:
```
client  = StrictRedisCluster(.., ssl=False,...)
```
`ClusterConnection` will be used as `connection_class` for `ClusterConnectionPool` that caused "unexpected keyword argument" error because we only pop `"ssl"` once in `SSLClusterConnection`
```
 File "/usr/lib/python2.7/site-packages/rediscluster/connection.py", line 231, in make_connection
    connection = self.connection_class(host=node["host"], port=node["port"], **self.connection_kwargs)
  File "/usr/lib/python2.7/site-packages/rediscluster/connection.py", line 46, in __init__
    super(ClusterConnection, self).__init__(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'ssl'
```