### PR TITLE
determine_node first while in pipeline and block some commands by node flag

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -306,7 +306,7 @@ class StrictRedisCluster(StrictRedis):
         node_flag = self.nodes_flags.get(command)
 
         if node_flag == 'blocked':
-            return blocked_command(self, command)
+            return blocked_command(command)
         elif node_flag == 'random':
             return [self.connection_pool.nodes.random_node()]
         elif node_flag == 'all-masters':

--- a/rediscluster/utils.py
+++ b/rediscluster/utils.py
@@ -42,11 +42,18 @@ def dict_merge(*dicts):
     return merged
 
 
-def blocked_command(self, command):
+def blocked_command(command):
     """
     Raises a `RedisClusterException` mentioning the command is blocked.
     """
     raise RedisClusterException("Command: {0} is blocked in redis cluster mode".format(command))
+
+
+def blocked_command_pipeline(command):
+    """
+    Raises a `RedisClusterException` mentioning the command is blocked in pipeline.
+    """
+    raise RedisClusterException("Command: {0} in pipeline is blocked in redis cluster mode".format(command))
 
 
 def merge_result(command, res):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,7 +114,7 @@ def test_dict_merge_value_error():
 
 def test_blocked_command():
     with pytest.raises(RedisClusterException) as ex:
-        blocked_command(None, "SET")
+        blocked_command("SET")
     assert unicode(ex.value) == "Command: SET is blocked in redis cluster mode"
 
 


### PR DESCRIPTION
1. determine_node before determin_slot while doing pipeline, the same logic with StrictRedisCluster.execute_command. some commands do not need to calc slot with key, such as cluster_countkeysinslot; 

2. block commands by node flag "blocked", "all-nodes", "all-masters";

3. delete the first useless arg for utils.blocked_command;