### PR TITLE
Fix "Target key name is busy" error when key already exists

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -726,7 +726,7 @@ class StrictRedisCluster(StrictRedis):
 
         return self.mset(**kwargs)
 
-    def rename(self, src, dst):
+    def rename(self, src, dst, replace=False):
         """
         Rename key ``src`` to ``dst``
 
@@ -748,7 +748,7 @@ class StrictRedisCluster(StrictRedis):
             ttl = 0
 
         self.delete(dst)
-        self.restore(dst, ttl, data)
+        self.restore(dst, ttl, data, replace)
         self.delete(src)
 
         return True


### PR DESCRIPTION
According Redis documentation __RESTORE__ command will return a "Target key name is busy" error when key already exists unless you use the __REPLACE__ modifier. I'm using this project in production and facing errors, because my pipeline performs an __RENAMENX__ operation.

The `redis-py` driver implements the replace option in :

```python
    def restore(self, name, ttl, value, replace=False):
        """
        Create a key using the provided serialized value, previously obtained
        using DUMP.
        """
        params = [name, ttl, value]
        if replace:
            params.append('REPLACE')
        return self.execute_command('RESTORE', *params)
```
[link](https://github.com/andymccurdy/redis-py/blob/1244f6e3f9d38379124622ff4f0371914ce759ae/redis/client.py#L1400-L1408)

So I made a change in `client.py` enabling a replace option.

Thank you.