### PR TITLE
Clearer exception message when cluster slots fails

### DIFF
--- a/rediscluster/exceptions.py
+++ b/rediscluster/exceptions.py
@@ -75,7 +75,20 @@ class MovedError(AskError):
     """
     pass
 
+
 class MasterDownError(ClusterDownError):
     """
     """
     pass
+
+
+class ClusterSlotsCommandError(RedisClusterException):
+    """
+    """
+    def __init__(self, node, cause):
+        super(ClusterSlotsCommandError, self).__init__(
+            "ERROR sending 'cluster slots' command to redis server: {0} - {1}".format(node, cause)
+        )
+
+        self.node = node
+        self.cause = cause

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -5,7 +5,7 @@ import random
 
 # rediscluster imports
 from .crc import crc16
-from .exceptions import RedisClusterException
+from .exceptions import RedisClusterException, ClusterSlotsCommandError
 
 # 3rd party imports
 from redis import StrictRedis
@@ -180,9 +180,9 @@ class NodeManager(object):
                 if 'CLUSTERDOWN' in e.message or 'MASTERDOWN' in e.message:
                     continue
                 else:
-                    raise RedisClusterException("ERROR sending 'cluster slots' command to redis server: {0}".format(node))
-            except Exception:
-                raise RedisClusterException("ERROR sending 'cluster slots' command to redis server: {0}".format(node))
+                    raise ClusterSlotsCommandError(node, e)
+            except Exception as e:
+                raise ClusterSlotsCommandError(node, e)
 
             all_slots_covered = True
 

--- a/tests/test_node_manager.py
+++ b/tests/test_node_manager.py
@@ -6,7 +6,7 @@ from __future__ import with_statement
 # rediscluster imports
 from tests.conftest import skip_if_server_version_lt
 from rediscluster import StrictRedisCluster
-from rediscluster.exceptions import RedisClusterException
+from rediscluster.exceptions import RedisClusterException, ClusterSlotsCommandError
 from rediscluster.nodemanager import NodeManager
 
 # 3rd party imports
@@ -284,7 +284,7 @@ def test_cluster_slots_error():
 
         n = NodeManager(startup_nodes=[{}])
 
-        with pytest.raises(RedisClusterException):
+        with pytest.raises(ClusterSlotsCommandError):
             n.initialize()
 
 


### PR DESCRIPTION
it was difficult to get to the bottom of the cause of the failed
cluster slots command messages so this adds the cause message into
the payload and adds the cause as a property