### PR TITLE
Handle ResponseError better in Python 3

### DIFF
--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -177,7 +177,8 @@ class NodeManager(object):
                 continue
             except ResponseError as e:
                 # Isn't a cluster connection, so it won't parse these exceptions automatically
-                if 'CLUSTERDOWN' in e.message or 'MASTERDOWN' in e.message:
+                message = e.__str__()
+                if 'CLUSTERDOWN' in message or 'MASTERDOWN' in message:
                     continue
                 else:
                     raise RedisClusterException("ERROR sending 'cluster slots' command to redis server: {0}".format(node))

--- a/tests/test_node_manager.py
+++ b/tests/test_node_manager.py
@@ -14,7 +14,7 @@ import pytest
 from mock import patch, Mock
 from redis import StrictRedis
 from redis._compat import unicode
-from redis import ConnectionError
+from redis import ConnectionError, ResponseError
 
 pytestmark = skip_if_server_version_lt('2.9.0')
 
@@ -279,13 +279,31 @@ def test_cluster_slots_error():
     Check that exception is raised if initialize can't execute
     'CLUSTER SLOTS' command.
     """
-    with patch.object(StrictRedisCluster, 'execute_command') as execute_command_mock:
+    with patch.object(StrictRedis, 'execute_command') as execute_command_mock:
         execute_command_mock.side_effect = Exception("foobar")
 
-        n = NodeManager(startup_nodes=[{}])
+        n = NodeManager(startup_nodes=[{"host": "127.0.0.1", "port": 7000}])
 
-        with pytest.raises(RedisClusterException):
+        with pytest.raises(RedisClusterException) as e:
             n.initialize()
+
+        assert "ERROR sending 'cluster slots' command" in unicode(e)
+
+
+def test_cluster_slots_error_expected_responseerror():
+    """
+    Check that exception is not raised if initialize can't execute
+    'CLUSTER SLOTS' command but can hit other nodes.
+    """
+    with patch.object(StrictRedis, 'execute_command') as execute_command_mock:
+        execute_command_mock.side_effect = ResponseError("MASTERDOWN")
+
+        n = NodeManager(startup_nodes=[{"host": "127.0.0.1", "port": 7000}])
+
+        with pytest.raises(RedisClusterException) as e:
+            n.initialize()
+
+        assert 'Redis Cluster cannot be connected' in unicode(e)
 
 
 def test_set_node():


### PR DESCRIPTION
Previously, we try to hit `ResponseError.message` to check if this is a `MASTERDOWN` or otherwise.

However, in Python 3, there's no `message` and instead we just need to cast the error to a string.

This should fix #278