### PR TITLE
Use Binary and Unicode literals instead of the helpers from redis-py

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -36,7 +36,7 @@ from .utils import (
 from redis import StrictRedis
 from redis.client import list_or_args, parse_info
 from redis.connection import Token
-from redis._compat import iteritems, basestring, b, izip, nativestr, long
+from redis._compat import iteritems, basestring, izip, nativestr, long
 from redis.exceptions import RedisError, ResponseError, TimeoutError, DataError, ConnectionError, BusyLoadingError
 
 
@@ -942,13 +942,13 @@ class StrictRedisCluster(StrictRedis):
            (start is not None and num is None):
             raise RedisError("RedisError: ``start`` and ``num`` must both be specified")
         try:
-            data_type = b(self.type(name))
+            data_type = self.type(name)
 
-            if data_type == b("none"):
+            if data_type == b"none":
                 return []
-            elif data_type == b("set"):
+            elif data_type == b"set":
                 data = list(self.smembers(name))[:]
-            elif data_type == b("list"):
+            elif data_type == b"list":
                 data = self.lrange(name, 0, -1)
             else:
                 raise RedisClusterException("Unable to sort data type : {0}".format(data_type))
@@ -969,10 +969,10 @@ class StrictRedisCluster(StrictRedis):
                 data = self._retrive_data_from_sort(data, get)
 
             if store is not None:
-                if data_type == b("set"):
+                if data_type == b"set":
                     self.delete(store)
                     self.rpush(store, *data)
-                elif data_type == b("list"):
+                elif data_type == b"list":
                     self.delete(store)
                     self.rpush(store, *data)
                 else:
@@ -1025,7 +1025,7 @@ class StrictRedisCluster(StrictRedis):
             single_item = k
         else:
             single_item = None
-        return b(single_item)
+        return single_item
 
     def _strtod_key_func(self, arg):
         """

--- a/tests/test_cluster_obj.py
+++ b/tests/test_cluster_obj.py
@@ -16,7 +16,7 @@ from tests.conftest import _get_client, skip_if_server_version_lt, skip_if_not_p
 
 # 3rd party imports
 from mock import patch, Mock, MagicMock
-from redis._compat import b, unicode
+from redis._compat import unicode
 from redis import StrictRedis
 import pytest
 
@@ -392,7 +392,7 @@ def assert_moved_redirection_on_slave(sr, connection_pool_cls, cluster_obj):
         master_value = {'host': '127.0.0.1', 'name': '127.0.0.1:7000', 'port': 7000, 'server_type': 'master'}
         with patch.object(ClusterConnectionPool, 'get_master_node_by_slot') as return_master_mock:
             return_master_mock.return_value = master_value
-            assert cluster_obj.get('foo16706') == b('foo')
+            assert cluster_obj.get('foo16706') == b'foo'
             assert return_slave_mock.call_count == 1
 
 
@@ -444,10 +444,11 @@ def test_access_correct_slave_with_readonly_mode_client(sr):
                 'get_master_node_by_slot',
                 return_value=master_value) as return_master_mock:
             readonly_client = StrictRedisCluster(host="127.0.0.1", port=7000, readonly_mode=True)
-            assert b('foo') == readonly_client.get('foo16706')
+
+            assert b'foo' == readonly_client.get('foo16706')
 
             readonly_client = StrictRedisCluster.from_url(url="redis://127.0.0.1:7000/0", readonly_mode=True)
-            assert b('foo') == readonly_client.get('foo16706')
+            assert b'foo' == readonly_client.get('foo16706')
 
 
 def test_refresh_using_specific_nodes(r):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,7 +12,7 @@ from tests.conftest import skip_if_server_version_lt, skip_if_redis_py_version_l
 
 # 3rd party imports
 import pytest
-from redis._compat import unichr, u, ascii_letters, iteritems, iterkeys, itervalues, unicode
+from redis._compat import unichr, ascii_letters, iteritems, iterkeys, itervalues, unicode
 from redis.client import parse_info
 from redis.exceptions import ResponseError, DataError, RedisError
 
@@ -234,7 +234,7 @@ class TestRedisCommands(object):
         assert r.get('a') is None
         byte_string = b'value'
         integer = 5
-        unicode_string = unichr(3456) + u('abcd') + unichr(3421)
+        unicode_string = unichr(3456) + 'abcd' + unichr(3421)
         assert r.set('byte_string', byte_string)
         assert r.set('integer', 5)
         assert r.set('unicode_string', unicode_string)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,7 +12,7 @@ from tests.conftest import skip_if_server_version_lt, skip_if_redis_py_version_l
 
 # 3rd party imports
 import pytest
-from redis._compat import unichr, u, b, ascii_letters, iteritems, iterkeys, itervalues, unicode
+from redis._compat import unichr, u, ascii_letters, iteritems, iterkeys, itervalues, unicode
 from redis.client import parse_info
 from redis.exceptions import ResponseError, DataError, RedisError
 
@@ -31,13 +31,13 @@ class TestRedisCommands(object):
     @skip_if_server_version_lt('2.9.9')
     def test_zrevrangebylex(self, r):
         r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
-        assert r.zrevrangebylex('a', '[c', '-') == [b('c'), b('b'), b('a')]
-        assert r.zrevrangebylex('a', '(c', '-') == [b('b'), b('a')]
+        assert r.zrevrangebylex('a', '[c', '-') == [b'c', b'b', b'a']
+        assert r.zrevrangebylex('a', '(c', '-') == [b'b', b'a']
         assert r.zrevrangebylex('a', '(g', '[aaa') == \
-            [b('f'), b('e'), b('d'), b('c'), b('b')]
-        assert r.zrevrangebylex('a', '+', '[f') == [b('g'), b('f')]
+            [b'f', b'e', b'd', b'c', b'b']
+        assert r.zrevrangebylex('a', '+', '[f') == [b'g', b'f']
         assert r.zrevrangebylex('a', '+', '-', start=3, num=2) == \
-            [b('d'), b('c')]
+            [b'd', b'c']
 
     def test_command_on_invalid_key_type(self, r):
         r.lpush('a', '1')
@@ -80,13 +80,13 @@ class TestRedisCommands(object):
 
     def test_echo(self, r):
         for server, res in r.echo('foo bar').items():
-            assert res == b('foo bar')
+            assert res == b'foo bar'
 
     def test_object(self, r):
         r['a'] = 'foo'
         assert isinstance(r.object('refcount', 'a'), int)
         assert isinstance(r.object('idletime', 'a'), int)
-        assert r.object('encoding', 'a') in (b('raw'), b('embstr'))
+        assert r.object('encoding', 'a') in (b'raw', b'embstr')
         assert r.object('idletime', 'invalid-key') is None
 
     def test_ping(self, r):
@@ -101,9 +101,9 @@ class TestRedisCommands(object):
     # BASIC KEY COMMANDS
     def test_append(self, r):
         assert r.append('a', 'a1') == 2
-        assert r['a'] == b('a1')
+        assert r['a'] == b'a1'
         assert r.append('a', 'a2') == 4
-        assert r['a'] == b('a1a2')
+        assert r['a'] == b'a1a2'
 
     def test_bitcount(self, r):
         r.setbit('a', 5, True)
@@ -138,11 +138,11 @@ class TestRedisCommands(object):
                 there for this command to work properly.
         """
         key = 'key:bitpos'
-        r.set(key, b('\xff\xf0\x00'))
+        r.set(key, b'\xff\xf0\x00')
         assert r.bitpos(key, 0) == 12
         assert r.bitpos(key, 0, 2, -1) == 16
         assert r.bitpos(key, 0, -2, -1) == 12
-        r.set(key, b('\x00\xff\xf0'))
+        r.set(key, b'\x00\xff\xf0')
         assert r.bitpos(key, 1, 0) == 8
         assert r.bitpos(key, 1, 1) == 8
         r.set(key, '\x00\x00\x00')
@@ -155,7 +155,7 @@ class TestRedisCommands(object):
         Bitpos was added in redis-py in version 2.10.2
         """
         key = 'key:bitpos:wrong:args'
-        r.set(key, b('\xff\xf0\x00'))
+        r.set(key, b'\xff\xf0\x00')
         with pytest.raises(RedisError):
             r.bitpos(key, 0, end=1) == 12
         with pytest.raises(RedisError):
@@ -163,11 +163,11 @@ class TestRedisCommands(object):
 
     def test_decr(self, r):
         assert r.decr('a') == -1
-        assert r['a'] == b('-1')
+        assert r['a'] == b'-1'
         assert r.decr('a') == -2
-        assert r['a'] == b('-2')
+        assert r['a'] == b'-2'
         assert r.decr('a', amount=5) == -7
-        assert r['a'] == b('-7')
+        assert r['a'] == b'-7'
 
     def test_delete(self, r):
         assert r.delete('a') == 0
@@ -191,7 +191,7 @@ class TestRedisCommands(object):
         dumped = r.dump('a')
         del r['a']
         r.restore('a', 0, dumped)
-        assert r['a'] == b('foo')
+        assert r['a'] == b'foo'
 
     def test_exists(self, r):
         assert not r.exists('a')
@@ -232,19 +232,19 @@ class TestRedisCommands(object):
     def test_get_and_set(self, r):
         # get and set can't be tested independently of each other
         assert r.get('a') is None
-        byte_string = b('value')
+        byte_string = b'value'
         integer = 5
         unicode_string = unichr(3456) + u('abcd') + unichr(3421)
         assert r.set('byte_string', byte_string)
         assert r.set('integer', 5)
         assert r.set('unicode_string', unicode_string)
         assert r.get('byte_string') == byte_string
-        assert r.get('integer') == b(str(integer))
+        assert r.get('integer') == str(integer).encode()
         assert r.get('unicode_string').decode('utf-8') == unicode_string
 
     def test_getitem_and_setitem(self, r):
         r['a'] = 'bar'
-        assert r['a'] == b('bar')
+        assert r['a'] == b'bar'
 
     def test_getitem_raises_keyerror_for_missing_key(self, r):
         with pytest.raises(KeyError):
@@ -268,76 +268,76 @@ class TestRedisCommands(object):
 
     def test_getrange(self, r):
         r['a'] = 'foo'
-        assert r.getrange('a', 0, 0) == b('f')
-        assert r.getrange('a', 0, 2) == b('foo')
-        assert r.getrange('a', 3, 4) == b('')
+        assert r.getrange('a', 0, 0) == b'f'
+        assert r.getrange('a', 0, 2) == b'foo'
+        assert r.getrange('a', 3, 4) == b''
 
     def test_getset(self, r):
         assert r.getset('a', 'foo') is None
-        assert r.getset('a', 'bar') == b('foo')
-        assert r.get('a') == b('bar')
+        assert r.getset('a', 'bar') == b'foo'
+        assert r.get('a') == b'bar'
 
     def test_incr(self, r):
         assert r.incr('a') == 1
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert r.incr('a') == 2
-        assert r['a'] == b('2')
+        assert r['a'] == b'2'
         assert r.incr('a', amount=5) == 7
-        assert r['a'] == b('7')
+        assert r['a'] == b'7'
 
     def test_incrby(self, r):
         assert r.incrby('a') == 1
         assert r.incrby('a', 4) == 5
-        assert r['a'] == b('5')
+        assert r['a'] == b'5'
 
     def test_incrbyfloat(self, r):
         assert r.incrbyfloat('a') == 1.0
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert r.incrbyfloat('a', 1.1) == 2.1
         assert float(r['a']) == float(2.1)
 
     def test_keys(self, r):
         keys = r.keys()
         assert keys == []
-        keys_with_underscores = set(['test_a', 'test_b'])
-        keys = keys_with_underscores.union(set(['testc']))
+        keys_with_underscores = set([b'test_a', b'test_b'])
+        keys = keys_with_underscores.union(set([b'testc']))
         for key in keys:
             r[key] = 1
-        assert set(r.keys(pattern='test_*')) == {b(k) for k in keys_with_underscores}
-        assert set(r.keys(pattern='test*')) == {b(k) for k in keys}
+        assert set(r.keys(pattern='test_*')) == {k for k in keys_with_underscores}
+        assert set(r.keys(pattern='test*')) == {k for k in keys}
 
     def test_mget(self, r):
         assert r.mget(['a', 'b']) == [None, None]
         r['a'] = '1'
         r['b'] = '2'
         r['c'] = '3'
-        assert r.mget('a', 'other', 'b', 'c') == [b('1'), None, b('2'), b('3')]
+        assert r.mget('a', 'other', 'b', 'c') == [b'1', None, b'2', b'3']
 
     def test_mset(self, r):
-        d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.mset(d)
         for k, v in iteritems(d):
             assert r[k] == v
 
     def test_mset_kwargs(self, r):
-        d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.mset(**d)
         for k, v in iteritems(d):
             assert r[k] == v
 
     def test_msetnx(self, r):
-        d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.msetnx(d)
-        d2 = {'a': b('x'), 'd': b('4')}
+        d2 = {'a': b'x', 'd': b'4'}
         assert not r.msetnx(d2)
         for k, v in iteritems(d):
             assert r[k] == v
         assert r.get('d') is None
 
     def test_msetnx_kwargs(self, r):
-        d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        d = {'a': b'1', 'b': b'2', 'c': b'3'}
         assert r.msetnx(**d)
-        d2 = {'a': b('x'), 'd': b('4')}
+        d2 = {'a': b'x', 'd': b'4'}
         assert not r.msetnx(**d2)
         for k, v in iteritems(d):
             assert r[k] == v
@@ -372,26 +372,26 @@ class TestRedisCommands(object):
 
     def test_psetex(self, r):
         assert r.psetex('a', 1000, 'value')
-        assert r['a'] == b('value')
+        assert r['a'] == b'value'
         assert 0 < r.pttl('a') <= 1000
 
     def test_psetex_timedelta(self, r):
         expire_at = datetime.timedelta(milliseconds=1000)
         assert r.psetex('a', expire_at, 'value')
-        assert r['a'] == b('value')
+        assert r['a'] == b'value'
         assert 0 < r.pttl('a') <= 1000
 
     def test_randomkey(self, r):
         assert r.randomkey() is None
         for key in ('a', 'b', 'c'):
             r[key] = 1
-        assert r.randomkey() in (b('a'), b('b'), b('c'))
+        assert r.randomkey() in (b'a', b'b', b'c')
 
     def test_rename(self, r):
         r['a'] = '1'
         assert r.rename('a', 'b')
         assert r.get('a') is None
-        assert r['b'] == b('1')
+        assert r['b'] == b'1'
 
         with pytest.raises(ResponseError) as ex:
             r.rename("foo", "foo")
@@ -406,27 +406,27 @@ class TestRedisCommands(object):
         r['a'] = '1'
         r['b'] = '2'
         assert not r.renamenx('a', 'b')
-        assert r['a'] == b('1')
-        assert r['b'] == b('2')
+        assert r['a'] == b'1'
+        assert r['b'] == b'2'
 
         assert r.renamenx('a', 'c')
-        assert r['c'] == b('1')
+        assert r['c'] == b'1'
 
     def test_set_nx(self, r):
         assert r.set('a', '1', nx=True)
         assert not r.set('a', '2', nx=True)
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
 
     def test_set_xx(self, r):
         assert not r.set('a', '1', xx=True)
         assert r.get('a') is None
         r['a'] = 'bar'
         assert r.set('a', '2', xx=True)
-        assert r.get('a') == b('2')
+        assert r.get('a') == b'2'
 
     def test_set_px(self, r):
         assert r.set('a', '1', px=10000)
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert 0 < r.pttl('a') <= 10000
         assert 0 < r.ttl('a') <= 10
 
@@ -452,21 +452,21 @@ class TestRedisCommands(object):
 
     def test_setex(self, r):
         assert r.setex('a', 60, '1')
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert 0 < r.ttl('a') <= 60
 
     def test_setnx(self, r):
         assert r.setnx('a', '1')
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
         assert not r.setnx('a', '2')
-        assert r['a'] == b('1')
+        assert r['a'] == b'1'
 
     def test_setrange(self, r):
         assert r.setrange('a', 5, 'foo') == 8
-        assert r['a'] == b('\0\0\0\0\0foo')
+        assert r['a'] == b'\0\0\0\0\0foo'
         r['a'] = 'abcdefghijh'
         assert r.setrange('a', 6, '12345') == 11
-        assert r['a'] == b('abcdef12345')
+        assert r['a'] == b'abcdef12345'
 
     def test_strlen(self, r):
         r['a'] = 'foo'
@@ -474,74 +474,74 @@ class TestRedisCommands(object):
 
     def test_substr(self, r):
         r['a'] = '0123456789'
-        assert r.substr('a', 0) == b('0123456789')
-        assert r.substr('a', 2) == b('23456789')
-        assert r.substr('a', 3, 5) == b('345')
-        assert r.substr('a', 3, -2) == b('345678')
+        assert r.substr('a', 0) == b'0123456789'
+        assert r.substr('a', 2) == b'23456789'
+        assert r.substr('a', 3, 5) == b'345'
+        assert r.substr('a', 3, -2) == b'345678'
 
     def test_type(self, r):
-        assert r.type('a') == b('none')
+        assert r.type('a') == b'none'
         r['a'] = '1'
-        assert r.type('a') == b('string')
+        assert r.type('a') == b'string'
         del r['a']
         r.lpush('a', '1')
-        assert r.type('a') == b('list')
+        assert r.type('a') == b'list'
         del r['a']
         r.sadd('a', '1')
-        assert r.type('a') == b('set')
+        assert r.type('a') == b'set'
         del r['a']
         r.zadd('a', **{'1': 1})
-        assert r.type('a') == b('zset')
+        assert r.type('a') == b'zset'
 
     # LIST COMMANDS
     def test_blpop(self, r):
         r.rpush('a{foo}', '1', '2')
         r.rpush('b{foo}', '3', '4')
-        assert r.blpop(['b{foo}', 'a{foo}'], timeout=1) == (b('b{foo}'), b('3'))
-        assert r.blpop(['b{foo}', 'a{foo}'], timeout=1) == (b('b{foo}'), b('4'))
-        assert r.blpop(['b{foo}', 'a{foo}'], timeout=1) == (b('a{foo}'), b('1'))
-        assert r.blpop(['b{foo}', 'a{foo}'], timeout=1) == (b('a{foo}'), b('2'))
+        assert r.blpop(['b{foo}', 'a{foo}'], timeout=1) == (b'b{foo}', b'3')
+        assert r.blpop(['b{foo}', 'a{foo}'], timeout=1) == (b'b{foo}', b'4')
+        assert r.blpop(['b{foo}', 'a{foo}'], timeout=1) == (b'a{foo}', b'1')
+        assert r.blpop(['b{foo}', 'a{foo}'], timeout=1) == (b'a{foo}', b'2')
         assert r.blpop(['b{foo}', 'a{foo}'], timeout=1) is None
         r.rpush('c{foo}', '1')
-        assert r.blpop('c{foo}', timeout=1) == (b('c{foo}'), b('1'))
+        assert r.blpop('c{foo}', timeout=1) == (b'c{foo}', b'1')
 
     def test_brpop(self, r):
         r.rpush('a{foo}', '1', '2')
         r.rpush('b{foo}', '3', '4')
-        assert r.brpop(['b{foo}', 'a{foo}'], timeout=1) == (b('b{foo}'), b('4'))
-        assert r.brpop(['b{foo}', 'a{foo}'], timeout=1) == (b('b{foo}'), b('3'))
-        assert r.brpop(['b{foo}', 'a{foo}'], timeout=1) == (b('a{foo}'), b('2'))
-        assert r.brpop(['b{foo}', 'a{foo}'], timeout=1) == (b('a{foo}'), b('1'))
+        assert r.brpop(['b{foo}', 'a{foo}'], timeout=1) == (b'b{foo}', b'4')
+        assert r.brpop(['b{foo}', 'a{foo}'], timeout=1) == (b'b{foo}', b'3')
+        assert r.brpop(['b{foo}', 'a{foo}'], timeout=1) == (b'a{foo}', b'2')
+        assert r.brpop(['b{foo}', 'a{foo}'], timeout=1) == (b'a{foo}', b'1')
         assert r.brpop(['b{foo}', 'a{foo}'], timeout=1) is None
         r.rpush('c{foo}', '1')
-        assert r.brpop('c{foo}', timeout=1) == (b('c{foo}'), b('1'))
+        assert r.brpop('c{foo}', timeout=1) == (b'c{foo}', b'1')
 
     def test_brpoplpush(self, r):
         r.rpush('a{foo}', '1', '2')
         r.rpush('b{foo}', '3', '4')
-        assert r.brpoplpush('a{foo}', 'b{foo}') == b('2')
-        assert r.brpoplpush('a{foo}', 'b{foo}') == b('1')
+        assert r.brpoplpush('a{foo}', 'b{foo}') == b'2'
+        assert r.brpoplpush('a{foo}', 'b{foo}') == b'1'
         assert r.brpoplpush('a{foo}', 'b{foo}', timeout=1) is None
         assert r.lrange('a{foo}', 0, -1) == []
-        assert r.lrange('b{foo}', 0, -1) == [b('1'), b('2'), b('3'), b('4')]
+        assert r.lrange('b{foo}', 0, -1) == [b'1', b'2', b'3', b'4']
 
     def test_brpoplpush_empty_string(self, r):
         r.rpush('a', '')
-        assert r.brpoplpush('a', 'b') == b('')
+        assert r.brpoplpush('a', 'b') == b''
 
     def test_lindex(self, r):
         r.rpush('a', '1', '2', '3')
-        assert r.lindex('a', '0') == b('1')
-        assert r.lindex('a', '1') == b('2')
-        assert r.lindex('a', '2') == b('3')
+        assert r.lindex('a', '0') == b'1'
+        assert r.lindex('a', '1') == b'2'
+        assert r.lindex('a', '2') == b'3'
 
     def test_linsert(self, r):
         r.rpush('a', '1', '2', '3')
         assert r.linsert('a', 'after', '2', '2.5') == 4
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('2.5'), b('3')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'2.5', b'3']
         assert r.linsert('a', 'before', '2', '1.5') == 5
         assert r.lrange('a', 0, -1) == \
-            [b('1'), b('1.5'), b('2'), b('2.5'), b('3')]
+            [b'1', b'1.5', b'2', b'2.5', b'3']
 
     def test_llen(self, r):
         r.rpush('a', '1', '2', '3')
@@ -549,74 +549,74 @@ class TestRedisCommands(object):
 
     def test_lpop(self, r):
         r.rpush('a', '1', '2', '3')
-        assert r.lpop('a') == b('1')
-        assert r.lpop('a') == b('2')
-        assert r.lpop('a') == b('3')
+        assert r.lpop('a') == b'1'
+        assert r.lpop('a') == b'2'
+        assert r.lpop('a') == b'3'
         assert r.lpop('a') is None
 
     def test_lpush(self, r):
         assert r.lpush('a', '1') == 1
         assert r.lpush('a', '2') == 2
         assert r.lpush('a', '3', '4') == 4
-        assert r.lrange('a', 0, -1) == [b('4'), b('3'), b('2'), b('1')]
+        assert r.lrange('a', 0, -1) == [b'4', b'3', b'2', b'1']
 
     def test_lpushx(self, r):
         assert r.lpushx('a', '1') == 0
         assert r.lrange('a', 0, -1) == []
         r.rpush('a', '1', '2', '3')
         assert r.lpushx('a', '4') == 4
-        assert r.lrange('a', 0, -1) == [b('4'), b('1'), b('2'), b('3')]
+        assert r.lrange('a', 0, -1) == [b'4', b'1', b'2', b'3']
 
     def test_lrange(self, r):
         r.rpush('a', '1', '2', '3', '4', '5')
-        assert r.lrange('a', 0, 2) == [b('1'), b('2'), b('3')]
-        assert r.lrange('a', 2, 10) == [b('3'), b('4'), b('5')]
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('3'), b('4'), b('5')]
+        assert r.lrange('a', 0, 2) == [b'1', b'2', b'3']
+        assert r.lrange('a', 2, 10) == [b'3', b'4', b'5']
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'3', b'4', b'5']
 
     def test_lrem(self, r):
         r.rpush('a', '1', '1', '1', '1')
         assert r.lrem('a', '1', 1) == 1
-        assert r.lrange('a', 0, -1) == [b('1'), b('1'), b('1')]
+        assert r.lrange('a', 0, -1) == [b'1', b'1', b'1']
         assert r.lrem('a', 0, '1') == 3
         assert r.lrange('a', 0, -1) == []
 
     def test_lset(self, r):
         r.rpush('a', '1', '2', '3')
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('3')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'3']
         assert r.lset('a', 1, '4')
-        assert r.lrange('a', 0, 2) == [b('1'), b('4'), b('3')]
+        assert r.lrange('a', 0, 2) == [b'1', b'4', b'3']
 
     def test_ltrim(self, r):
         r.rpush('a', '1', '2', '3')
         assert r.ltrim('a', 0, 1)
-        assert r.lrange('a', 0, -1) == [b('1'), b('2')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2']
 
     def test_rpop(self, r):
         r.rpush('a', '1', '2', '3')
-        assert r.rpop('a') == b('3')
-        assert r.rpop('a') == b('2')
-        assert r.rpop('a') == b('1')
+        assert r.rpop('a') == b'3'
+        assert r.rpop('a') == b'2'
+        assert r.rpop('a') == b'1'
         assert r.rpop('a') is None
 
     def test_rpoplpush(self, r):
         r.rpush('a', 'a1', 'a2', 'a3')
         r.rpush('b', 'b1', 'b2', 'b3')
-        assert r.rpoplpush('a', 'b') == b('a3')
-        assert r.lrange('a', 0, -1) == [b('a1'), b('a2')]
-        assert r.lrange('b', 0, -1) == [b('a3'), b('b1'), b('b2'), b('b3')]
+        assert r.rpoplpush('a', 'b') == b'a3'
+        assert r.lrange('a', 0, -1) == [b'a1', b'a2']
+        assert r.lrange('b', 0, -1) == [b'a3', b'b1', b'b2', b'b3']
 
     def test_rpush(self, r):
         assert r.rpush('a', '1') == 1
         assert r.rpush('a', '2') == 2
         assert r.rpush('a', '3', '4') == 4
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('3'), b('4')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'3', b'4']
 
     def test_rpushx(self, r):
         assert r.rpushx('a', 'b') == 0
         assert r.lrange('a', 0, -1) == []
         r.rpush('a', '1', '2', '3')
         assert r.rpushx('a', '4') == 4
-        assert r.lrange('a', 0, -1) == [b('1'), b('2'), b('3'), b('4')]
+        assert r.lrange('a', 0, -1) == [b'1', b'2', b'3', b'4']
 
     # SCAN COMMANDS
     def test_scan(self, r):
@@ -629,81 +629,81 @@ class TestRedisCommands(object):
             assert cursor == 0
             keys += partial_keys
 
-        assert set(keys) == set([b('a'), b('b'), b('c')])
+        assert set(keys) == set([b'a', b'b', b'c'])
 
         keys = []
         for result in r.scan(match='a').values():
             cursor, partial_keys = result
             assert cursor == 0
             keys += partial_keys
-        assert set(keys) == set([b('a')])
+        assert set(keys) == set([b'a'])
 
     def test_scan_iter(self, r):
         alphabet = 'abcdefghijklmnopqrstuvwABCDEFGHIJKLMNOPQRSTUVW'
         for i, c in enumerate(alphabet):
             r.set(c, i)
         keys = list(r.scan_iter())
-        expected_result = [b(c) for c in alphabet]
+        expected_result = [c.encode() for c in alphabet]
         assert set(keys) == set(expected_result)
 
         keys = list(r.scan_iter(match='a'))
-        assert set(keys) == set([b('a')])
+        assert set(keys) == set([b'a'])
 
         r.set('Xa', 1)
         r.set('Xb', 2)
         r.set('Xc', 3)
         keys = list(r.scan_iter('X*', count=1000))
         assert len(keys) == 3
-        assert set(keys) == set([b('Xa'), b('Xb'), b('Xc')])
+        assert set(keys) == set([b'Xa', b'Xb', b'Xc'])
 
     def test_sscan(self, r):
         r.sadd('a', 1, 2, 3)
         cursor, members = r.sscan('a')
         assert cursor == 0
-        assert set(members) == set([b('1'), b('2'), b('3')])
-        _, members = r.sscan('a', match=b('1'))
-        assert set(members) == set([b('1')])
+        assert set(members) == set([b'1', b'2', b'3'])
+        _, members = r.sscan('a', match=b'1')
+        assert set(members) == set([b'1'])
 
     def test_sscan_iter(self, r):
         r.sadd('a', 1, 2, 3)
         members = list(r.sscan_iter('a'))
-        assert set(members) == set([b('1'), b('2'), b('3')])
-        members = list(r.sscan_iter('a', match=b('1')))
-        assert set(members) == set([b('1')])
+        assert set(members) == set([b'1', b'2', b'3'])
+        members = list(r.sscan_iter('a', match=b'1'))
+        assert set(members) == set([b'1'])
 
     def test_hscan(self, r):
         r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
         cursor, dic = r.hscan('a')
         assert cursor == 0
-        assert dic == {b('a'): b('1'), b('b'): b('2'), b('c'): b('3')}
+        assert dic == {b'a': b'1', b'b': b'2', b'c': b'3'}
         _, dic = r.hscan('a', match='a')
-        assert dic == {b('a'): b('1')}
+        assert dic == {b'a': b'1'}
 
     def test_hscan_iter(self, r):
         r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
         dic = dict(r.hscan_iter('a'))
-        assert dic == {b('a'): b('1'), b('b'): b('2'), b('c'): b('3')}
+        assert dic == {b'a': b'1', b'b': b'2', b'c': b'3'}
         dic = dict(r.hscan_iter('a', match='a'))
-        assert dic == {b('a'): b('1')}
+        assert dic == {b'a': b'1'}
 
     def test_zscan(self, r):
         r.zadd('a', 1, 'a', 2, 'b', 3, 'c')
         cursor, pairs = r.zscan('a')
         assert cursor == 0
-        assert set(pairs) == set([(b('a'), 1), (b('b'), 2), (b('c'), 3)])
+        assert set(pairs) == set([(b'a', 1), (b'b', 2), (b'c', 3)])
         _, pairs = r.zscan('a', match='a')
-        assert set(pairs) == set([(b('a'), 1)])
+        assert set(pairs) == set([(b'a', 1)])
 
     def test_zscan_iter(self, r):
         r.zadd('a', 1, 'a', 2, 'b', 3, 'c')
         pairs = list(r.zscan_iter('a'))
-        assert set(pairs) == set([(b('a'), 1), (b('b'), 2), (b('c'), 3)])
+        assert set(pairs) == set([(b'a', 1), (b'b', 2), (b'c', 3)])
         pairs = list(r.zscan_iter('a', match='a'))
-        assert set(pairs) == set([(b('a'), 1)])
+        assert set(pairs) == set([(b'a', 1)])
 
     # SET COMMANDS
     def test_sadd(self, r):
-        members = set([b('1'), b('2'), b('3')])
+        members = set([b'1', b'2', b'3'])
         r.sadd('a', *members)
         assert r.smembers('a') == members
 
@@ -713,17 +713,17 @@ class TestRedisCommands(object):
 
     def test_sdiff(self, r):
         r.sadd('a{foo}', '1', '2', '3')
-        assert r.sdiff('a{foo}', 'b{foo}') == set([b('1'), b('2'), b('3')])
+        assert r.sdiff('a{foo}', 'b{foo}') == set([b'1', b'2', b'3'])
         r.sadd('b{foo}', '2', '3')
-        assert r.sdiff('a{foo}', 'b{foo}') == set([b('1')])
+        assert r.sdiff('a{foo}', 'b{foo}') == set([b'1'])
 
     def test_sdiffstore(self, r):
         r.sadd('a{foo}', '1', '2', '3')
         assert r.sdiffstore('c{foo}', 'a{foo}', 'b{foo}') == 3
-        assert r.smembers('c{foo}') == set([b('1'), b('2'), b('3')])
+        assert r.smembers('c{foo}') == set([b'1', b'2', b'3'])
         r.sadd('b{foo}', '2', '3')
         assert r.sdiffstore('c{foo}', 'a{foo}', 'b{foo}') == 1
-        assert r.smembers('c{foo}') == set([b('1')])
+        assert r.smembers('c{foo}') == set([b'1'])
 
         # Diff:s that return empty set should not fail
         r.sdiffstore('d{foo}', 'e{foo}') == 0
@@ -732,7 +732,7 @@ class TestRedisCommands(object):
         r.sadd('a{foo}', '1', '2', '3')
         assert r.sinter('a{foo}', 'b{foo}') == set()
         r.sadd('b{foo}', '2', '3')
-        assert r.sinter('a{foo}', 'b{foo}') == set([b('2'), b('3')])
+        assert r.sinter('a{foo}', 'b{foo}') == set([b'2', b'3'])
 
     def test_sinterstore(self, r):
         r.sadd('a{foo}', '1', '2', '3')
@@ -740,7 +740,7 @@ class TestRedisCommands(object):
         assert r.smembers('c{foo}') == set()
         r.sadd('b{foo}', '2', '3')
         assert r.sinterstore('c{foo}', 'a{foo}', 'b{foo}') == 2
-        assert r.smembers('c{foo}') == set([b('2'), b('3')])
+        assert r.smembers('c{foo}') == set([b'2', b'3'])
 
     def test_sismember(self, r):
         r.sadd('a', '1', '2', '3')
@@ -751,29 +751,29 @@ class TestRedisCommands(object):
 
     def test_smembers(self, r):
         r.sadd('a', '1', '2', '3')
-        assert r.smembers('a') == set([b('1'), b('2'), b('3')])
+        assert r.smembers('a') == set([b'1', b'2', b'3'])
 
     def test_smove(self, r):
         r.sadd('a{foo}', 'a1', 'a2')
         r.sadd('b{foo}', 'b1', 'b2')
         assert r.smove('a{foo}', 'b{foo}', 'a1')
-        assert r.smembers('a{foo}') == set([b('a2')])
-        assert r.smembers('b{foo}') == set([b('b1'), b('b2'), b('a1')])
+        assert r.smembers('a{foo}') == set([b'a2'])
+        assert r.smembers('b{foo}') == set([b'b1', b'b2', b'a1'])
 
     def test_spop(self, r):
-        s = [b('1'), b('2'), b('3')]
+        s = [b'1', b'2', b'3']
         r.sadd('a', *s)
         value = r.spop('a')
         assert value in s
         assert r.smembers('a') == set(s) - set([value])
 
     def test_srandmember(self, r):
-        s = [b('1'), b('2'), b('3')]
+        s = [b'1', b'2', b'3']
         r.sadd('a', *s)
         assert r.srandmember('a') in s
 
     def test_srandmember_multi_value(self, r):
-        s = [b('1'), b('2'), b('3')]
+        s = [b'1', b'2', b'3']
         r.sadd('a', *s)
         randoms = r.srandmember('a', number=2)
         assert len(randoms) == 2
@@ -783,23 +783,23 @@ class TestRedisCommands(object):
         r.sadd('a', '1', '2', '3', '4')
         assert r.srem('a', '5') == 0
         assert r.srem('a', '2', '4') == 2
-        assert r.smembers('a') == set([b('1'), b('3')])
+        assert r.smembers('a') == set([b'1', b'3'])
 
     def test_sunion(self, r):
         r.sadd('a{foo}', '1', '2')
         r.sadd('b{foo}', '2', '3')
-        assert r.sunion('a{foo}', 'b{foo}') == set([b('1'), b('2'), b('3')])
+        assert r.sunion('a{foo}', 'b{foo}') == set([b'1', b'2', b'3'])
 
     def test_sunionstore(self, r):
         r.sadd('a{foo}', '1', '2')
         r.sadd('b{foo}', '2', '3')
         assert r.sunionstore('c{foo}', 'a{foo}', 'b{foo}') == 3
-        assert r.smembers('c{foo}') == set([b('1'), b('2'), b('3')])
+        assert r.smembers('c{foo}') == set([b'1', b'2', b'3'])
 
     # SORTED SET COMMANDS
     def test_zadd(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a2'), b('a3')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a2', b'a3']
 
     def test_zcard(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
@@ -837,7 +837,7 @@ class TestRedisCommands(object):
         r.zadd('c{foo}', a1=6, a3=5, a4=4)
         assert r.zinterstore('d{foo}', ['a{foo}', 'b{foo}', 'c{foo}']) == 2
         assert r.zrange('d{foo}', 0, -1, withscores=True) == \
-            [(b('a3'), 8), (b('a1'), 9)]
+            [(b'a3', 8), (b'a1', 9)]
 
     def test_zinterstore_max(self, r):
         r.zadd('a{foo}', a1=1, a2=1, a3=1)
@@ -845,7 +845,7 @@ class TestRedisCommands(object):
         r.zadd('c{foo}', a1=6, a3=5, a4=4)
         assert r.zinterstore('d{foo}', ['a{foo}', 'b{foo}', 'c{foo}'], aggregate='MAX') == 2
         assert r.zrange('d{foo}', 0, -1, withscores=True) == \
-            [(b('a3'), 5), (b('a1'), 6)]
+            [(b'a3', 5), (b'a1', 6)]
 
     def test_zinterstore_min(self, r):
         r.zadd('a{foo}', a1=1, a2=2, a3=3)
@@ -853,7 +853,7 @@ class TestRedisCommands(object):
         r.zadd('c{foo}', a1=6, a3=5, a4=4)
         assert r.zinterstore('d{foo}', ['a{foo}', 'b{foo}', 'c{foo}'], aggregate='MIN') == 2
         assert r.zrange('d{foo}', 0, -1, withscores=True) == \
-            [(b('a1'), 1), (b('a3'), 3)]
+            [(b'a1', 1), (b'a3', 3)]
 
     def test_zinterstore_with_weight(self, r):
         r.zadd('a{foo}', a1=1, a2=1, a3=1)
@@ -861,48 +861,48 @@ class TestRedisCommands(object):
         r.zadd('c{foo}', a1=6, a3=5, a4=4)
         assert r.zinterstore('d{foo}', {'a{foo}': 1, 'b{foo}': 2, 'c{foo}': 3}) == 2
         assert r.zrange('d{foo}', 0, -1, withscores=True) == \
-            [(b('a3'), 20), (b('a1'), 23)]
+            [(b'a3', 20), (b'a1', 23)]
 
     def test_zrange(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
-        assert r.zrange('a', 0, 1) == [b('a1'), b('a2')]
-        assert r.zrange('a', 1, 2) == [b('a2'), b('a3')]
+        assert r.zrange('a', 0, 1) == [b'a1', b'a2']
+        assert r.zrange('a', 1, 2) == [b'a2', b'a3']
 
         # withscores
         assert r.zrange('a', 0, 1, withscores=True) == \
-            [(b('a1'), 1.0), (b('a2'), 2.0)]
+            [(b'a1', 1.0), (b'a2', 2.0)]
         assert r.zrange('a', 1, 2, withscores=True) == \
-            [(b('a2'), 2.0), (b('a3'), 3.0)]
+            [(b'a2', 2.0), (b'a3', 3.0)]
 
         # custom score function
         assert r.zrange('a', 0, 1, withscores=True, score_cast_func=int) == \
-            [(b('a1'), 1), (b('a2'), 2)]
+            [(b'a1', 1), (b'a2', 2)]
 
     def test_zrangebylex(self, r):
         r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
-        assert r.zrangebylex('a', '-', '[c') == [b('a'), b('b'), b('c')]
-        assert r.zrangebylex('a', '-', '(c') == [b('a'), b('b')]
+        assert r.zrangebylex('a', '-', '[c') == [b'a', b'b', b'c']
+        assert r.zrangebylex('a', '-', '(c') == [b'a', b'b']
         assert r.zrangebylex('a', '[aaa', '(g') == \
-            [b('b'), b('c'), b('d'), b('e'), b('f')]
-        assert r.zrangebylex('a', '[f', '+') == [b('f'), b('g')]
-        assert r.zrangebylex('a', '-', '+', start=3, num=2) == [b('d'), b('e')]
+            [b'b', b'c', b'd', b'e', b'f']
+        assert r.zrangebylex('a', '[f', '+') == [b'f', b'g']
+        assert r.zrangebylex('a', '-', '+', start=3, num=2) == [b'd', b'e']
 
     def test_zrangebyscore(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
-        assert r.zrangebyscore('a', 2, 4) == [b('a2'), b('a3'), b('a4')]
+        assert r.zrangebyscore('a', 2, 4) == [b'a2', b'a3', b'a4']
 
         # slicing with start/num
         assert r.zrangebyscore('a', 2, 4, start=1, num=2) == \
-            [b('a3'), b('a4')]
+            [b'a3', b'a4']
 
         # withscores
         assert r.zrangebyscore('a', 2, 4, withscores=True) == \
-            [(b('a2'), 2.0), (b('a3'), 3.0), (b('a4'), 4.0)]
+            [(b'a2', 2.0), (b'a3', 3.0), (b'a4', 4.0)]
 
         # custom score function
         assert r.zrangebyscore('a', 2, 4, withscores=True,
                                score_cast_func=int) == \
-            [(b('a2'), 2), (b('a3'), 3), (b('a4'), 4)]
+            [(b'a2', 2), (b'a3', 3), (b'a4', 4)]
 
     def test_zrank(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
@@ -913,68 +913,68 @@ class TestRedisCommands(object):
     def test_zrem(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
         assert r.zrem('a', 'a2') == 1
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a3')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a3']
         assert r.zrem('a', 'b') == 0
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a3')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a3']
 
     def test_zrem_multiple_keys(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
         assert r.zrem('a', 'a1', 'a2') == 2
-        assert r.zrange('a', 0, 5) == [b('a3')]
+        assert r.zrange('a', 0, 5) == [b'a3']
 
     def test_zremrangebylex(self, r):
         r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
         assert r.zremrangebylex('a', '-', '[c') == 3
-        assert r.zrange('a', 0, -1) == [b('d'), b('e'), b('f'), b('g')]
+        assert r.zrange('a', 0, -1) == [b'd', b'e', b'f', b'g']
         assert r.zremrangebylex('a', '[f', '+') == 2
-        assert r.zrange('a', 0, -1) == [b('d'), b('e')]
+        assert r.zrange('a', 0, -1) == [b'd', b'e']
         assert r.zremrangebylex('a', '[h', '+') == 0
-        assert r.zrange('a', 0, -1) == [b('d'), b('e')]
+        assert r.zrange('a', 0, -1) == [b'd', b'e']
 
     def test_zremrangebyrank(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
         assert r.zremrangebyrank('a', 1, 3) == 3
-        assert r.zrange('a', 0, 5) == [b('a1'), b('a5')]
+        assert r.zrange('a', 0, 5) == [b'a1', b'a5']
 
     def test_zremrangebyscore(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
         assert r.zremrangebyscore('a', 2, 4) == 3
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a5')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a5']
         assert r.zremrangebyscore('a', 2, 4) == 0
-        assert r.zrange('a', 0, -1) == [b('a1'), b('a5')]
+        assert r.zrange('a', 0, -1) == [b'a1', b'a5']
 
     def test_zrevrange(self, r):
         r.zadd('a', a1=1, a2=2, a3=3)
-        assert r.zrevrange('a', 0, 1) == [b('a3'), b('a2')]
-        assert r.zrevrange('a', 1, 2) == [b('a2'), b('a1')]
+        assert r.zrevrange('a', 0, 1) == [b'a3', b'a2']
+        assert r.zrevrange('a', 1, 2) == [b'a2', b'a1']
 
         # withscores
         assert r.zrevrange('a', 0, 1, withscores=True) == \
-            [(b('a3'), 3.0), (b('a2'), 2.0)]
+            [(b'a3', 3.0), (b'a2', 2.0)]
         assert r.zrevrange('a', 1, 2, withscores=True) == \
-            [(b('a2'), 2.0), (b('a1'), 1.0)]
+            [(b'a2', 2.0), (b'a1', 1.0)]
 
         # custom score function
         assert r.zrevrange('a', 0, 1, withscores=True,
                            score_cast_func=int) == \
-            [(b('a3'), 3.0), (b('a2'), 2.0)]
+            [(b'a3', 3.0), (b'a2', 2.0)]
 
     def test_zrevrangebyscore(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
-        assert r.zrevrangebyscore('a', 4, 2) == [b('a4'), b('a3'), b('a2')]
+        assert r.zrevrangebyscore('a', 4, 2) == [b'a4', b'a3', b'a2']
 
         # slicing with start/num
         assert r.zrevrangebyscore('a', 4, 2, start=1, num=2) == \
-            [b('a3'), b('a2')]
+            [b'a3', b'a2']
 
         # withscores
         assert r.zrevrangebyscore('a', 4, 2, withscores=True) == \
-            [(b('a4'), 4.0), (b('a3'), 3.0), (b('a2'), 2.0)]
+            [(b'a4', 4.0), (b'a3', 3.0), (b'a2', 2.0)]
 
         # custom score function
         assert r.zrevrangebyscore('a', 4, 2, withscores=True,
                                   score_cast_func=int) == \
-            [(b('a4'), 4), (b('a3'), 3), (b('a2'), 2)]
+            [(b'a4', 4), (b'a3', 3), (b'a2', 2)]
 
     def test_zrevrank(self, r):
         r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
@@ -1002,7 +1002,7 @@ class TestRedisCommands(object):
         r.zadd('c{foo}', a1=6, a3=5, a4=4)
         assert r.zunionstore('d{foo}', ['a{foo}', 'b{foo}', 'c{foo}']) == 4
         assert r.zrange('d{foo}', 0, -1, withscores=True) == \
-            [(b('a2'), 3), (b('a4'), 4), (b('a3'), 8), (b('a1'), 9)]
+            [(b'a2', 3), (b'a4', 4), (b'a3', 8), (b'a1', 9)]
 
     def test_zunionstore_max(self, r):
         r.zadd('a{foo}', a1=1, a2=1, a3=1)
@@ -1010,7 +1010,7 @@ class TestRedisCommands(object):
         r.zadd('c{foo}', a1=6, a3=5, a4=4)
         assert r.zunionstore('d{foo}', ['a{foo}', 'b{foo}', 'c{foo}'], aggregate='MAX') == 4
         assert r.zrange('d{foo}', 0, -1, withscores=True) == \
-            [(b('a2'), 2), (b('a4'), 4), (b('a3'), 5), (b('a1'), 6)]
+            [(b'a2', 2), (b'a4', 4), (b'a3', 5), (b'a1', 6)]
 
     def test_zunionstore_min(self, r):
         r.zadd('a{foo}', a1=1, a2=2, a3=3)
@@ -1018,7 +1018,7 @@ class TestRedisCommands(object):
         r.zadd('c{foo}', a1=6, a3=5, a4=4)
         assert r.zunionstore('d{foo}', ['a{foo}', 'b{foo}', 'c{foo}'], aggregate='MIN') == 4
         assert r.zrange('d{foo}', 0, -1, withscores=True) == \
-            [(b('a1'), 1), (b('a2'), 2), (b('a3'), 3), (b('a4'), 4)]
+            [(b'a1', 1), (b'a2', 2), (b'a3', 3), (b'a4', 4)]
 
     def test_zunionstore_with_weight(self, r):
         r.zadd('a{foo}', a1=1, a2=1, a3=1)
@@ -1026,11 +1026,11 @@ class TestRedisCommands(object):
         r.zadd('c{foo}', a1=6, a3=5, a4=4)
         assert r.zunionstore('d{foo}', {'a{foo}': 1, 'b{foo}': 2, 'c{foo}': 3}) == 4
         assert r.zrange('d{foo}', 0, -1, withscores=True) == \
-            [(b('a2'), 5), (b('a4'), 12), (b('a3'), 20), (b('a1'), 23)]
+            [(b'a2', 5), (b'a4', 12), (b'a3', 20), (b'a1', 23)]
 
 #     # HYPERLOGLOG TESTS
     def test_pfadd(self, r):
-        members = set([b('1'), b('2'), b('3')])
+        members = set([b'1', b'2', b'3'])
         assert r.pfadd('a', *members) == 1
         assert r.pfadd('a', *members) == 0
         assert r.pfcount('a') == len(members)
@@ -1038,18 +1038,18 @@ class TestRedisCommands(object):
     @pytest.mark.xfail(reason="New pfcount in 2.10.5 currently breaks in cluster")
     @skip_if_server_version_lt('2.8.9')
     def test_pfcount(self, r):
-        members = set([b('1'), b('2'), b('3')])
+        members = set([b'1', b'2', b'3'])
         r.pfadd('a', *members)
         assert r.pfcount('a') == len(members)
-        members_b = set([b('2'), b('3'), b('4')])
+        members_b = set([b'2', b'3', b'4'])
         r.pfadd('b', *members_b)
         assert r.pfcount('b') == len(members_b)
         assert r.pfcount('a', 'b') == len(members_b.union(members))
 
     def test_pfmerge(self, r):
-        mema = set([b('1'), b('2'), b('3')])
-        memb = set([b('2'), b('3'), b('4')])
-        memc = set([b('5'), b('6'), b('7')])
+        mema = set([b'1', b'2', b'3'])
+        memb = set([b'2', b'3', b'4'])
+        memc = set([b'5', b'6', b'7'])
         r.pfadd('a', *mema)
         r.pfadd('b', *memb)
         r.pfadd('c', *memc)
@@ -1061,17 +1061,17 @@ class TestRedisCommands(object):
     # HASH COMMANDS
     def test_hget_and_hset(self, r):
         r.hmset('a', {'1': 1, '2': 2, '3': 3})
-        assert r.hget('a', '1') == b('1')
-        assert r.hget('a', '2') == b('2')
-        assert r.hget('a', '3') == b('3')
+        assert r.hget('a', '1') == b'1'
+        assert r.hget('a', '2') == b'2'
+        assert r.hget('a', '3') == b'3'
 
         # field was updated, redis returns 0
         assert r.hset('a', '2', 5) == 0
-        assert r.hget('a', '2') == b('5')
+        assert r.hget('a', '2') == b'5'
 
         # field is new, redis returns 1
         assert r.hset('a', '4', 4) == 1
-        assert r.hget('a', '4') == b('4')
+        assert r.hget('a', '4') == b'4'
 
         # key inside of hash that doesn't exist returns null value
         assert r.hget('a', 'b') is None
@@ -1089,7 +1089,7 @@ class TestRedisCommands(object):
         assert not r.hexists('a', '4')
 
     def test_hgetall(self, r):
-        h = {b('a1'): b('1'), b('a2'): b('2'), b('a3'): b('3')}
+        h = {b'a1': b'1', b'a2': b'2', b'a3': b'3'}
         r.hmset('a', h)
         assert r.hgetall('a') == h
 
@@ -1104,7 +1104,7 @@ class TestRedisCommands(object):
         assert r.hincrbyfloat('a', '1', 1.2) == 3.2
 
     def test_hkeys(self, r):
-        h = {b('a1'): b('1'), b('a2'): b('2'), b('a3'): b('3')}
+        h = {b'a1': b'1', b'a2': b'2', b'a3': b'3'}
         r.hmset('a', h)
         local_keys = list(iterkeys(h))
         remote_keys = r.hkeys('a')
@@ -1116,22 +1116,22 @@ class TestRedisCommands(object):
 
     def test_hmget(self, r):
         assert r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
-        assert r.hmget('a', 'a', 'b', 'c') == [b('1'), b('2'), b('3')]
+        assert r.hmget('a', 'a', 'b', 'c') == [b'1', b'2', b'3']
 
     def test_hmset(self, r):
-        h = {b('a'): b('1'), b('b'): b('2'), b('c'): b('3')}
+        h = {b'a': b'1', b'b': b'2', b'c': b'3'}
         assert r.hmset('a', h)
         assert r.hgetall('a') == h
 
     def test_hsetnx(self, r):
         # Initially set the hash field
         assert r.hsetnx('a', '1', 1)
-        assert r.hget('a', '1') == b('1')
+        assert r.hget('a', '1') == b'1'
         assert not r.hsetnx('a', '1', 2)
-        assert r.hget('a', '1') == b('1')
+        assert r.hget('a', '1') == b'1'
 
     def test_hvals(self, r):
-        h = {b('a1'): b('1'), b('a2'): b('2'), b('a3'): b('3')}
+        h = {b'a1': b'1', b'a2': b'2', b'a3': b'3'}
         r.hmset('a', h)
         local_vals = list(itervalues(h))
         remote_vals = r.hvals('a')
@@ -1140,33 +1140,33 @@ class TestRedisCommands(object):
     # SORT
     def test_sort_basic(self, r):
         r.rpush('a', '3', '2', '1', '4')
-        assert r.sort('a') == [b('1'), b('2'), b('3'), b('4')]
+        assert r.sort('a') == [b'1', b'2', b'3', b'4']
 
     def test_sort_limited(self, r):
         r.rpush('a', '3', '2', '1', '4')
-        assert r.sort('a', start=1, num=2) == [b('2'), b('3')]
+        assert r.sort('a', start=1, num=2) == [b'2', b'3']
 
     def test_sort_by(self, r):
         r['score:1'] = 8
         r['score:2'] = 3
         r['score:3'] = 5
         r.rpush('a', '3', '2', '1')
-        assert r.sort('a', by='score:*') == [b('2'), b('3'), b('1')]
+        assert r.sort('a', by='score:*') == [b'2', b'3', b'1']
 
     def test_sort_get(self, r):
         r['user:1'] = 'u1'
         r['user:2'] = 'u2'
         r['user:3'] = 'u3'
         r.rpush('a', '2', '3', '1')
-        assert r.sort('a', get='user:*') == [b('u1'), b('u2'), b('u3')]
+        assert r.sort('a', get='user:*') == [b'u1', b'u2', b'u3']
 
     def test_sort_get_multi(self, r):
-        r['user:1'] = 'u1'
-        r['user:2'] = 'u2'
-        r['user:3'] = 'u3'
+        r['user:1'] = b'u1'
+        r['user:2'] = b'u2'
+        r['user:3'] = b'u3'
         r.rpush('a', '2', '3', '1')
         assert r.sort('a', get=('user:*', '#')) == \
-            [b('u1'), b('1'), b('u2'), b('2'), b('u3'), b('3')]
+            [b'u1', '1', b'u2', '2', b'u3', '3']
 
     def test_sort_get_groups_two(self, r):
         r['user:1'] = 'u1'
@@ -1174,7 +1174,7 @@ class TestRedisCommands(object):
         r['user:3'] = 'u3'
         r.rpush('a', '2', '3', '1')
         assert r.sort('a', get=('user:*', '#'), groups=True) == \
-            [(b('u1'), b('1')), (b('u2'), b('2')), (b('u3'), b('3'))]
+            [(b'u1', '1'), (b'u2', '2'), (b'u3', '3')]
 
     def test_sort_groups_string_get(self, r):
         r['user:1'] = 'u1'
@@ -1201,32 +1201,32 @@ class TestRedisCommands(object):
             r.sort('a', groups=True)
 
     def test_sort_groups_three_gets(self, r):
-        r['user:1'] = 'u1'
-        r['user:2'] = 'u2'
-        r['user:3'] = 'u3'
-        r['door:1'] = 'd1'
-        r['door:2'] = 'd2'
-        r['door:3'] = 'd3'
+        r['user:1'] = b'u1'
+        r['user:2'] = b'u2'
+        r['user:3'] = b'u3'
+        r['door:1'] = b'd1'
+        r['door:2'] = b'd2'
+        r['door:3'] = b'd3'
         r.rpush('a', '2', '3', '1')
         assert r.sort('a', get=('user:*', 'door:*', '#'), groups=True) == [
-            (b('u1'), b('d1'), b('1')),
-            (b('u2'), b('d2'), b('2')),
-            (b('u3'), b('d3'), b('3'))
+            (b'u1', b'd1', '1'),
+            (b'u2', b'd2', '2'),
+            (b'u3', b'd3', '3')
         ]
 
     def test_sort_desc(self, r):
         r.rpush('a', '2', '3', '1')
-        assert r.sort('a', desc=True) == [b('3'), b('2'), b('1')]
+        assert r.sort('a', desc=True) == [b'3', b'2', b'1']
 
     def test_sort_alpha(self, r):
         r.rpush('a', 'e', 'c', 'b', 'd', 'a')
         assert r.sort('a', alpha=True) == \
-            [b('a'), b('b'), b('c'), b('d'), b('e')]
+            [b'a', b'b', b'c', b'd', b'e']
 
     def test_sort_store(self, r):
         r.rpush('a', '2', '3', '1')
         assert r.sort('a', store='sorted_values') == 3
-        assert r.lrange('sorted_values', 0, -1) == [b('1'), b('2'), b('3')]
+        assert r.lrange('sorted_values', 0, -1) == [b'1', b'2', b'3']
 
     def test_sort_all_options(self, r):
         r['user:1:username'] = 'zeus'
@@ -1253,7 +1253,7 @@ class TestRedisCommands(object):
                      store='sorted')
         assert num == 4
         assert r.lrange('sorted', 0, 10) == \
-            [b('vodka'), b('milk'), b('gin'), b('apple juice')]
+            [b'vodka', b'milk', b'gin', b'apple juice']
 
 
 class TestStrictCommands(object):
@@ -1261,16 +1261,16 @@ class TestStrictCommands(object):
     def test_strict_zadd(self, sr):
         sr.zadd('a', 1.0, 'a1', 2.0, 'a2', a3=3.0)
         assert sr.zrange('a', 0, -1, withscores=True) == \
-            [(b('a1'), 1.0), (b('a2'), 2.0), (b('a3'), 3.0)]
+            [(b'a1', 1.0), (b'a2', 2.0), (b'a3', 3.0)]
 
     def test_strict_lrem(self, sr):
         sr.rpush('a', 'a1', 'a2', 'a3', 'a1')
         sr.lrem('a', 0, 'a1')
-        assert sr.lrange('a', 0, -1) == [b('a2'), b('a3')]
+        assert sr.lrange('a', 0, -1) == [b'a2', b'a3']
 
     def test_strict_setex(self, sr):
         assert sr.setex('a', 60, '1')
-        assert sr['a'] == b('1')
+        assert sr['a'] == b'1'
         assert 0 < sr.ttl('a') <= 60
 
     def test_strict_ttl(self, sr):
@@ -1291,25 +1291,25 @@ class TestStrictCommands(object):
 
     def test_eval(self, sr):
         res = sr.eval("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", 2, "A{foo}", "B{foo}", "first", "second")
-        assert res[0] == b('A{foo}')
-        assert res[1] == b('B{foo}')
-        assert res[2] == b('first')
-        assert res[3] == b('second')
+        assert res[0] == b'A{foo}'
+        assert res[1] == b'B{foo}'
+        assert res[2] == b'first'
+        assert res[3] == b'second'
 
 
 class TestBinarySave(object):
     def test_binary_get_set(self, r):
         assert r.set(' foo bar ', '123')
-        assert r.get(' foo bar ') == b('123')
+        assert r.get(' foo bar ') == b'123'
 
         assert r.set(' foo\r\nbar\r\n ', '456')
-        assert r.get(' foo\r\nbar\r\n ') == b('456')
+        assert r.get(' foo\r\nbar\r\n ') == b'456'
 
         assert r.set(' \r\n\t\x07\x13 ', '789')
-        assert r.get(' \r\n\t\x07\x13 ') == b('789')
+        assert r.get(' \r\n\t\x07\x13 ') == b'789'
 
         assert sorted(r.keys('*')) == \
-            [b(' \r\n\t\x07\x13 '), b(' foo\r\nbar\r\n '), b(' foo bar ')]
+            [b' \r\n\t\x07\x13 ', b' foo\r\nbar\r\n ', b' foo bar ']
 
         assert r.delete(' foo bar ')
         assert r.delete(' foo\r\nbar\r\n ')
@@ -1317,9 +1317,9 @@ class TestBinarySave(object):
 
     def test_binary_lists(self, r):
         mapping = {
-            b('foo bar'): [b('1'), b('2'), b('3')],
-            b('foo\r\nbar\r\n'): [b('4'), b('5'), b('6')],
-            b('foo\tbar\x07'): [b('7'), b('8'), b('9')],
+            b'foo bar': [b'1', b'2', b'3'],
+            b'foo\r\nbar\r\n': [b'4', b'5', b'6'],
+            b'foo\tbar\x07': [b'7', b'8', b'9'],
         }
         # fill in lists
         for key, value in iteritems(mapping):
@@ -1371,7 +1371,7 @@ class TestBinarySave(object):
         # load up 100K of data into a key
         data = ''.join([ascii_letters] * (100000 // len(ascii_letters)))
         r['a'] = data
-        assert r['a'] == b(data)
+        assert r['a'] == data.encode()
 
     def test_floating_point_encoding(self, r):
         """

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -13,7 +13,7 @@ from tests.conftest import _get_client
 # 3rd party imports
 import pytest
 from mock import patch
-from redis._compat import u, unichr, unicode
+from redis._compat import unichr, unicode
 from redis.exceptions import WatchError, ResponseError, ConnectionError
 
 
@@ -239,7 +239,7 @@ class TestPipeline(object):
         assert r['a'] == b'1'
 
     def test_exec_error_in_no_transaction_pipeline_unicode_command(self, r):
-        key = unichr(3456) + u('abcd') + unichr(3421)
+        key = unichr(3456) + 'abcd' + unichr(3421)
         r[key] = 1
         with r.pipeline(transaction=False) as pipe:
             pipe.llen(key)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -14,7 +14,7 @@ import pytest
 # import redis
 from redis import StrictRedis, Redis
 from redis.exceptions import ConnectionError
-from redis._compat import basestring, u, unichr, b
+from redis._compat import basestring, u, unichr
 
 from .conftest import skip_if_server_version_lt, skip_if_redis_py_version_lt
 
@@ -487,7 +487,7 @@ class TestPubSubPubSubSubcommands(object):
     def test_pubsub_channels(self, r):
         r.pubsub(ignore_subscribe_messages=True).subscribe('foo', 'bar', 'baz', 'quux')
         channels = sorted(r.pubsub_channels())
-        assert channels == [b('bar'), b('baz'), b('foo'), b('quux')]
+        assert channels == [b'bar', b'baz', b'foo', b'quux']
 
     @skip_if_redis_py_version_lt('2.10.6')
     def test_pubsub_numsub(self, r):
@@ -495,7 +495,7 @@ class TestPubSubPubSubSubcommands(object):
         r.pubsub(ignore_subscribe_messages=True).subscribe('bar', 'baz')
         r.pubsub(ignore_subscribe_messages=True).subscribe('baz')
 
-        channels = [(b('bar'), 2), (b('baz'), 3), (b('foo'), 1)]
+        channels = [(b'bar', 2), (b'baz', 3), (b'foo', 1)]
         assert channels == sorted(r.pubsub_numsub('foo', 'bar', 'baz'))
 
     @skip_if_redis_py_version_lt('2.10.6')

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -14,7 +14,7 @@ import pytest
 # import redis
 from redis import StrictRedis, Redis
 from redis.exceptions import ConnectionError
-from redis._compat import basestring, u, unichr
+from redis._compat import basestring, unichr
 
 from .conftest import skip_if_server_version_lt, skip_if_redis_py_version_lt
 
@@ -48,7 +48,7 @@ def make_subscribe_test_data(pubsub, type):
             'unsub_type': 'unsubscribe',
             'sub_func': pubsub.subscribe,
             'unsub_func': pubsub.unsubscribe,
-            'keys': ['foo', 'bar', u('uni') + unichr(4456) + u('code')]
+            'keys': ['foo', 'bar', 'uni' + unichr(4456) + 'code']
         }
     elif type == 'pattern':
         return {
@@ -57,7 +57,7 @@ def make_subscribe_test_data(pubsub, type):
             'unsub_type': 'punsubscribe',
             'sub_func': pubsub.psubscribe,
             'unsub_func': pubsub.punsubscribe,
-            'keys': ['f*', 'b*', u('uni') + unichr(4456) + u('*')]
+            'keys': ['f*', 'b*', 'uni' + unichr(4456) + '*']
         }
     assert False, 'invalid subscribe type: {0}'.format(type)
 
@@ -309,7 +309,7 @@ class TestPubSubMessages(object):
     @pytest.mark.xfail(reason="Pattern pubsub do not work currently")
     def test_unicode_channel_message_handler(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
-        channel = u('uni') + unichr(4456) + u('code')
+        channel = 'uni' + unichr(4456) + 'code'
         channels = {channel: self.message_handler}
         print(channels)
         p.subscribe(**channels)
@@ -320,8 +320,8 @@ class TestPubSubMessages(object):
     @pytest.mark.xfail(reason="Pattern pubsub do not work currently")
     def test_unicode_pattern_message_handler(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
-        pattern = u('uni') + unichr(4456) + u('*')
-        channel = u('uni') + unichr(4456) + u('code')
+        pattern = 'uni' + unichr(4456) + '*'
+        channel = 'uni' + unichr(4456) + 'code'
         p.psubscribe(**{pattern: self.message_handler})
         assert r.publish(channel, 'test message') == 1
         assert wait_for_message(p) is None
@@ -332,9 +332,9 @@ class TestPubSubMessages(object):
 class TestPubSubAutoDecoding(object):
     "These tests only validate that we get unicode values back"
 
-    channel = u('uni') + unichr(4456) + u('code')
-    pattern = u('uni') + unichr(4456) + u('*')
-    data = u('abc') + unichr(4458) + u('123')
+    channel = 'uni' + unichr(4456) + 'code'
+    pattern = 'uni' + unichr(4456) + '*'
+    data = 'abc' + unichr(4458) + '123'
 
     def make_message(self, type, channel, data, pattern=None):
         return {
@@ -400,7 +400,7 @@ class TestPubSubAutoDecoding(object):
         # test that we reconnected to the correct channel
         p.connection.disconnect()
         assert wait_for_message(p) is None  # should reconnect
-        new_data = self.data + u('new data')
+        new_data = self.data + 'new data'
         o.publish(self.channel, new_data)
         assert wait_for_message(p) is None
         assert self.message == self.make_message('message', self.channel,
@@ -419,7 +419,7 @@ class TestPubSubAutoDecoding(object):
         # test that we reconnected to the correct pattern
         p.connection.disconnect()
         assert wait_for_message(p) is None  # should reconnect
-        new_data = self.data + u('new data')
+        new_data = self.data + 'new data'
         o.publish(self.channel, new_data)
         assert wait_for_message(p) is None
         assert self.message == self.make_message('pmessage', self.channel,

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -8,7 +8,6 @@ from rediscluster.exceptions import RedisClusterException
 
 # 3rd party imports
 from redis import exceptions
-from redis._compat import b
 import pytest
 
 
@@ -114,7 +113,7 @@ class TestScripting(object):
         assert multiply.sha
         assert r.script_exists(multiply.sha) == [True]
         # [SET worked, GET 'a', result of multiple script]
-        assert pipe.execute() == [True, b('2'), 6]
+        assert pipe.execute() == [True, b'2', 6]
 
         # purge the script from redis's cache and re-run the pipeline
         # the multiply script object knows it's sha, so it shouldn't get
@@ -127,7 +126,7 @@ class TestScripting(object):
         multiply(keys=['a'], args=[3], client=pipe)
         assert r.script_exists(multiply.sha) == [False]
         # [SET worked, GET 'a', result of multiple script]
-        assert pipe.execute() == [True, b('2'), 6]
+        assert pipe.execute() == [True, b'2', 6]
 
     @pytest.mark.xfail(reason="Not Yet Implemented")
     def test_eval_msgpack_pipeline_error_in_lua(self, r):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ from rediscluster.utils import (
 
 # 3rd party imports
 import pytest
-from redis._compat import unicode, b
+from redis._compat import unicode
 
 
 def test_parse_cluster_slots():
@@ -71,16 +71,16 @@ def test_parse_cluster_slots():
     parse_cluster_slots(extended_mock_response)
 
     mock_binary_response = [
-        [0, 5460, [b('172.17.0.2'), 7000], [b('172.17.0.2'), 7003]],
-        [5461, 10922, [b('172.17.0.2'), 7001], [b('172.17.0.2'), 7004]],
-        [10923, 16383, [b('172.17.0.2'), 7002], [b('172.17.0.2'), 7005]]
+        [0, 5460, [b'172.17.0.2', 7000], [b'172.17.0.2', 7003]],
+        [5461, 10922, [b'172.17.0.2', 7001], [b'172.17.0.2', 7004]],
+        [10923, 16383, [b'172.17.0.2', 7002], [b'172.17.0.2', 7005]]
     ]
     parse_cluster_slots(mock_binary_response)
 
     extended_mock_binary_response = [
-        [0, 5460, [b('172.17.0.2'), 7000, b('ffd36d8d7cb10d813f81f9662a835f6beea72677')], [b('172.17.0.2'), 7003, b('5c15b69186017ddc25ebfac81e74694fc0c1a160')]],
-        [5461, 10922, [b('172.17.0.2'), 7001, b('069cda388c7c41c62abe892d9e0a2d55fbf5ffd5')], [b('172.17.0.2'), 7004, b('dc152a08b4cf1f2a0baf775fb86ad0938cb907dc')]],
-        [10923, 16383, [b('172.17.0.2'), 7002, b('3588b4cf9fc72d57bb262a024747797ead0cf7ea')], [b('172.17.0.2'), 7005, b('a72c02c7d85f4ec3145ab2c411eefc0812aa96b0')]]
+        [0, 5460, [b'172.17.0.2', 7000, b'ffd36d8d7cb10d813f81f9662a835f6beea72677'], [b'172.17.0.2', 7003, b'5c15b69186017ddc25ebfac81e74694fc0c1a160']],
+        [5461, 10922, [b'172.17.0.2', 7001, b'069cda388c7c41c62abe892d9e0a2d55fbf5ffd5'], [b'172.17.0.2', 7004, b'dc152a08b4cf1f2a0baf775fb86ad0938cb907dc']],
+        [10923, 16383, [b'172.17.0.2', 7002, b'3588b4cf9fc72d57bb262a024747797ead0cf7ea'], [b'172.17.0.2', 7005, b'a72c02c7d85f4ec3145ab2c411eefc0812aa96b0']]
     ]
 
     extended_mock_parsed = {


### PR DESCRIPTION
These helpers are being removed in the next version of `redis-py` (`>=3.0`).  With that in mind, I cleaned up and converted everything to the same systems that are used by the new version of `redis-py`.

This should help us upgrade to `redis-py >= 3.0`
