### PR TITLE
ensure OBJECT command is directed to correct node

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -285,7 +285,10 @@ class StrictRedisCluster(StrictRedis):
                 raise RedisClusterException("{0} - all keys must map to the same key slot".format(command))
             return slots.pop()
 
-        key = args[1]
+        if command == 'OBJECT':
+            key = args[2]
+        else:
+            key = args[1]
 
         return self.connection_pool.nodes.keyslot(key)
 

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -285,10 +285,11 @@ class StrictRedisCluster(StrictRedis):
                 raise RedisClusterException("{0} - all keys must map to the same key slot".format(command))
             return slots.pop()
 
-        if command == 'OBJECT':
+        key = args[1]
+
+        # OBJEECT command uses a special keyword as first positional argument
+        if command = 'OBJECT':
             key = args[2]
-        else:
-            key = args[1]
 
         return self.connection_pool.nodes.keyslot(key)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -85,8 +85,8 @@ class TestRedisCommands(object):
     def test_object(self, r):
         r['a'] = 'foo'
         assert isinstance(r.object('refcount', 'a'), int)
-        # assert isinstance(r.object('idletime', 'a'), int)
-        # assert r.object('encoding', 'a') in (b('raw'), b('embstr'))
+        assert isinstance(r.object('idletime', 'a'), int)
+        assert r.object('encoding', 'a') in (b('raw'), b('embstr'))
         assert r.object('idletime', 'invalid-key') is None
 
     def test_ping(self, r):


### PR DESCRIPTION
The `OBJECT` command ends up getting sent to the wrong node.

Because this is an uncommon edge case, I added a special case within `_determine_node` so we correctly find the `key` we're working with when using an `OBJECT` command.