### PR TITLE
drop Python 3.3 support and add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
-  - "3.6-dev"
+  - "3.6"
+  - "3.7"
   - "nightly"
 services:
   - redis-server

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35, py36, hi27, hi33, hi34, hi35, flake8-py34, flake8-py27
+envlist = py27, py34, py35, py36, py37, hi27, hi34, hi35, hi36, hi37, flake8-py34, flake8-py27
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt
@@ -12,12 +12,6 @@ commands = python {envbindir}/coverage run --source rediscluster -p -m py.test
 
 [testenv:hi27]
 basepython = python2.7
-deps =
-    -r{toxinidir}/dev-requirements.txt
-    hiredis == 0.2.0
-
-[testenv:hi33]
-basepython = python3.3
 deps =
     -r{toxinidir}/dev-requirements.txt
     hiredis == 0.2.0
@@ -30,6 +24,18 @@ deps =
 
 [testenv:hi35]
 basepython = python3.5
+deps = 
+    -r{toxinidir}/dev-requirements.txt
+    hiredis == 0.2.0
+
+[testenv:hi36]
+basepython = python3.6
+deps = 
+    -r{toxinidir}/dev-requirements.txt
+    hiredis == 0.2.0
+
+[testenv:hi37]
+basepython = python3.7
 deps = 
     -r{toxinidir}/dev-requirements.txt
     hiredis == 0.2.0


### PR DESCRIPTION
Python 3.3 is no longer supported by the version of setuptools getting pulled in.