### PR TITLE
Add xenial dist to support python 3.7+.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial
 language: python
 python:
   - "2.7"
@@ -32,13 +33,13 @@ env:
   - HIREDIS=1 REDIS_VERSION=5.0
 script: 
   - make start
-#  - coverage erase
-#  - coverage run --source rediscluster -p -m py.test
+  - coverage erase
+  - coverage run --source rediscluster -p -m py.test
   - py.test
   - make stop
-# after_success: 
-#   - coverage combine
-#   - coveralls
+after_success:
+  - coverage combine
+  - coveralls
 matrix:
   allow_failures:
     - python: "nightly"


### PR DESCRIPTION
Attempt to fix the failing build on python 3.7.

According to the Travis CI docs, python 3.7 and higher require the `xenial` distribution.
https://docs.travis-ci.com/user/languages/python/#python-37-and-higher