### PR TITLE
fix(XREAD, XREADGROUP): fixes broken key lookup for stream xread & xreadgroup

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -10,7 +10,6 @@ import time
 # rediscluster imports
 from .connection import (
     ClusterConnectionPool,
-    ClusterCrossSlotError,
     ClusterReadOnlyConnectionPool,
     ClusterWithReadReplicasConnectionPool,
     SSLClusterConnection,
@@ -310,7 +309,7 @@ class RedisCluster(Redis):
             keys = args[3: 3 + numkeys]
             slots = {self.connection_pool.nodes.keyslot(key) for key in keys}
             if len(slots) != 1:
-                raise ClusterCrossSlotError("Keys in request don't hash to the same slot")
+                raise RedisClusterException("{0} - all keys must map to the same key slot".format(command))
             return slots.pop()
 
         if command in ['XREADGROUP', 'XREAD']:
@@ -320,7 +319,7 @@ class RedisCluster(Redis):
             keys = keys_ids[: idx_split]
             slots = {self.connection_pool.nodes.keyslot(key) for key in keys}
             if len(slots) != 1:
-                raise ClusterCrossSlotError("Keys in request don't hash to the same slot")
+                raise RedisClusterException("{0} - all keys must map to the same key slot".format(command))
             return slots.pop()
 
         key = args[1]

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -10,6 +10,7 @@ import time
 # rediscluster imports
 from .connection import (
     ClusterConnectionPool,
+    ClusterCrossSlotError,
     ClusterReadOnlyConnectionPool,
     ClusterWithReadReplicasConnectionPool,
     SSLClusterConnection,
@@ -309,7 +310,17 @@ class RedisCluster(Redis):
             keys = args[3: 3 + numkeys]
             slots = {self.connection_pool.nodes.keyslot(key) for key in keys}
             if len(slots) != 1:
-                raise RedisClusterException("{0} - all keys must map to the same key slot".format(command))
+                raise ClusterCrossSlotError("Keys in request don't hash to the same slot")
+            return slots.pop()
+
+        if command in ['XREADGROUP', 'XREAD']:
+            tokens = {args[i].value: i for i in range(len(args)) if type(args[i]) == Token}
+            keys_ids = list(args[tokens['STREAMS'] + 1: ])
+            idx_split = len(keys_ids) // 2
+            keys = keys_ids[: idx_split]
+            slots = {self.connection_pool.nodes.keyslot(key) for key in keys}
+            if len(slots) != 1:
+                raise ClusterCrossSlotError("Keys in request don't hash to the same slot")
             return slots.pop()
 
         key = args[1]


### PR DESCRIPTION
### In this PR:
- modify `self._determine_slot()` such that it can successfully parse out stream names from `xreadgroup` and `xread` commands

### I didn't know anything was broken. What exactly is being fixed here? 🤔 
- I was experimenting with using streams for an upcoming feature, started running into `rediscluster.exceptions.ClusterError: TTL exhausted.` when using `xread` and `xreadgroup`
- `execute_command` was receiving 16 `MovedError`s in a row as it was continually executing the `xreadgroup` command against the wrong node
- additional tracing points to the fact that `slot` variable was set to different slot than the one being returned in the `MovedError`

**2 possible solutions came to mind:**

**1.** at the end of `except MovedError...` block add the following code:
`if e.slot != slot: `
`    slot=e.slot`
**2.** figure out why `self._determine_slot()` was returning the wrong slot

This PR implement solution **2.**

### Additional Information:
`xread` and `xreadgroup` are structured differently than most other commands.  Consider the following examples:
`execute command called with args: ('XPENDING', 'my_stream', 'my_stream.cg-1', '-', '+', '1')`
`execute command called with args: ('XREADGROUP', GROUP, 'my_stream.cg-1', 'c-1', COUNT, '1', BLOCK, '100', STREAMS, 'my_stream', '>')`
`execute command called with args: ('XREAD', COUNT, '1', STREAMS, 'realtime.nlp', '$')`

in `xpending` the first element of the tuple after the command is `my_stream`
in `xreadgroup` the first element of the tuple after the command is `Token('GROUP')`
in `xread` the first element after the command will be either `Token('COUNT')` or `Token('STREAMS')`, depending whether or not the `count` argument is being used. It could also be `Token('BLOCK')` if that argument is being used.

**Here's another caveat of this bug:**
- Currently, no matter what, the hash slot for `xreadgroup` will ALWAYS be wrong, as it is hashing `Token('GROUP')`
- However if the resulting hash slot for `Token('GROUP')` lies on the same node as your stream name, this bug won't occur
- `xread` can be even harder to see as it's hash slot can be the result of 1 of 3 different `Token` objects, depending on what arguments you are calling it with

### I still don't believe you how can I replicate this bug?
- start up a redis 5.0.5 cluster with 3 master nodes & 3 read replicas
- use `xadd` to create and add some data to a stream
- use `xgroup_create` to create a consumer group for the stream
- use `xreadgroup` to read data from that consumer group
- watch as you get a `rediscluster.exceptions.ClusterError: TTL exhausted.` error
- didn't get the error? Try a different stream name, see caveats above ^