### PR TITLE
Fixed bug preventing reinitialization after fixing MOVED errors

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -4,6 +4,7 @@ Release Notes
 2.1.0 (xxx yy, 2019)
 
     * Updated redis-py compatbile version to support any version in the major version 3.0.x, 3.1.x, 3.2.x, 3.3.x. (#326)
+    * Fixed bug preventing reinitialization after getting MOVED errors
 
 2.0.0 (Aug 12, 2019)
 

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -240,7 +240,7 @@ class NodeManager(object):
         self.reinitialize_counter = 0
 
     def increment_reinitialize_counter(self, ct=1):
-        for i in range(1, ct):
+        for i in range(min(ct, self.reinitialize_steps)):
             self.reinitialize_counter += 1
             if self.reinitialize_counter % self.reinitialize_steps == 0:
                 self.initialize()


### PR DESCRIPTION
Basically, the default of ct=1 was a no-op.

Also prevent looping excessively if ct is larger than reinitialize_steps, since it's pointless.