### PR TITLE
Added Clustered Blocking Connection Pool and Accompanying Tests

### DIFF
--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -467,7 +467,7 @@ class ClusterBlockingConnectionPool(ClusterConnectionPool):
 
         except Empty:
             # queue is full of connections to other nodes
-            if not self.max_connections_per_node and len(connections_to_other_nodes) == self.max_connections:
+            if len(connections_to_other_nodes) == self.max_connections:
                 # is the earliest released / longest un-used connection
                 connection_to_clear = connections_to_other_nodes.pop()
                 self._connections.remove(connection_to_clear)

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -516,7 +516,7 @@ class ClusterBlockingConnectionPool(ClusterConnectionPool):
             pass
 
     def disconnect(self):
-        "Disconnects all connections in the pool."
+        """Disconnects all connections in the pool."""
         for connection in self._connections:
             connection.disconnect()
 

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -418,10 +418,10 @@ class ClusterBlockingConnectionPool(ClusterConnectionPool):
         self._check_lock = threading.Lock()
 
         """
-        We could use a conditional branch on ``max_connections_per_node`` to see which pool to initialize, 
+        We could use a conditional branch on ``max_connections_per_node`` to see which pool to initialize,
         but ClusterConnectionPool calls ConnectionPool init which has no concept of ``max_connections_per_node``,
         and also performs ``reset()``. This will lead to an attribute error.
-        
+
         This could suggest removing inheritance from ConnectionPool, but initializing both should not add much overhead.
         """
         self._pool_by_node = defaultdict(self.blocking_pool_factory)

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -463,7 +463,7 @@ class ClusterBlockingConnectionPool(ClusterConnectionPool):
             connection = pool.get(block=True, timeout=self.timeout)
             while connection is not None and connection.node != node:
                 connections_to_other_nodes.append(connection)
-                connection = self.get_pool(node=node).get(block=True, timeout=self.timeout)
+                connection = pool.get(block=True, timeout=self.timeout)
 
         except Empty:
             # Note that this is not caught by the redis cluster client and will be

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -7,7 +7,6 @@ import random
 import threading
 from contextlib import contextmanager
 from itertools import chain
-from queue import LifoQueue, Full, Empty
 from collections import defaultdict
 
 # rediscluster imports
@@ -19,7 +18,7 @@ from .exceptions import (
 )
 
 # 3rd party imports
-from redis._compat import nativestr
+from redis._compat import nativestr, LifoQueue, Full, Empty
 from redis.client import dict_merge
 from redis.connection import ConnectionPool, Connection, DefaultParser, SSLConnection
 from redis.exceptions import ConnectionError

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -515,7 +515,7 @@ class ClusterBlockingConnectionPool(ClusterConnectionPool):
     def disconnect(self):
         "Disconnects all connections in the pool."
         for connection in self._connections:
-                connection.disconnect()
+            connection.disconnect()
 
 
 class ClusterReadOnlyConnectionPool(ClusterConnectionPool):

--- a/tests/test_cluster_connection_pool.py
+++ b/tests/test_cluster_connection_pool.py
@@ -261,13 +261,11 @@ class TestClusterBlockingConnectionPool(object):
         pool = self.get_pool(max_connections=1, max_connections_per_node=True, timeout=2)
         c1 = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
 
-        def release_connection_after_sleep(*args, **kwargs):
-            def inner(connection):
-                time.sleep(0.1)
-                pool.release(connection)
-            return inner
+        def release_connection_after_sleep(connection):
+            time.sleep(0.1)
+            pool.release(connection)
 
-        Thread(target=release_connection_after_sleep(c1)).start()
+        Thread(target=release_connection_after_sleep, args=(c1,)).start()
         start = time.time()
 
         # different node so should not block
@@ -277,7 +275,7 @@ class TestClusterBlockingConnectionPool(object):
         pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
         assert time.time() - start >= 0.1
 
-        Thread(target=release_connection_after_sleep(c2)).start()
+        Thread(target=release_connection_after_sleep, args=(c2,)).start()
         start = time.time()
         pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
         assert time.time() - start >= 0.1

--- a/tests/test_cluster_connection_pool.py
+++ b/tests/test_cluster_connection_pool.py
@@ -179,8 +179,12 @@ class TestConnectionPool(object):
 
 
 class TestClusterBlockingConnectionPool(object):
-    def get_pool(self, connection_kwargs=None, max_connections=None, max_connections_per_node=None,
+    def get_pool(self, connection_kwargs=None, max_connections=100, max_connections_per_node=None,
                  connection_class=DummyConnection, init_slot_cache=True, timeout=20):
+        '''
+        Setting max_connections default to 100 instead of None (which === 2**31) like in ClusterConnectionPool as
+        BlockingClusterConnectionPool takes time to setup a queue containing max_connections num of elements
+        '''
         connection_kwargs = connection_kwargs or {}
         pool = ClusterBlockingConnectionPool(
             startup_nodes=[{"host": "127.0.0.1", "port": 7000}],


### PR DESCRIPTION
Built ClusterBlockingConnectionPool based on the BlockingConnectionPool in redis-py.

Enabled it for clustering following the adjustments made in ClusterConnectionPool.
Adapted the tests for BlockingConnectionPool similarly and added some extra cases.

Fixed some typos along the way.

Currently includes a solution for supporting `max_connections_per_node = False` though it is somewhat naive. I have another PR that only supports `max_connections_per_node = True` which simply removes this option, gating it behind `NotImplementedError` in case that's better.