### PR TITLE
fix: ClusterConnectionPool.count_all_num_connections is not thread safe in python 3

### DIFF
--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -220,9 +220,10 @@ class ClusterConnectionPool(ConnectionPool):
         """
         Create a new connection
         """
-        if self.count_all_num_connections(node) >= self.max_connections:
+        num_connections = self.count_all_num_connections(node)
+        if num_connections >= self.max_connections:
             if self.max_connections_per_node:
-                raise RedisClusterException("Too many connection ({0}) for node: {1}".format(self.count_all_num_connections(node), node['name']))
+                raise RedisClusterException("Too many connection ({0}) for node: {1}".format(num_connections, node['name']))
 
             raise RedisClusterException("Too many connections")
 
@@ -275,7 +276,7 @@ class ClusterConnectionPool(ConnectionPool):
         if self.max_connections_per_node:
             return self._created_connections_per_node.get(node['name'], 0)
 
-        return sum([i for i in self._created_connections_per_node.values()])
+        return sum([i for i in list(self._created_connections_per_node.values())])
 
     def get_random_connection(self):
         """


### PR DESCRIPTION
In python 3, `dict.values()` is an iterator, whereas in python 2 it
returns a copy of the values as a list.

When running under python 3 and multiple threads, that means the
dictionary _created_connections_per_node is now able to be mutated and
iterated over at the same time, thus raising a RuntimeError.

The race comes from multiple threads calling
`ClusterConnectionPool.make_connection` at the same time.

Coercing the `.values()` to a `list()` _appears_ to the best of my
knowledge to be locked by the GIL and doesn't cause this issue.

I have stress tested this with: https://gist.github.com/mattrobenolt/e88d940c9afa6a18d6b39328eeb9a8f6

https://sentry.io/share/issue/7e8780304998400a934c0dbeb9eab888/