### PR TITLE
added back python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 cache: pip
 python:
   - "2.7"
+  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,6 +89,7 @@ Python versions should follow the same supported python versions as specificed b
 If this library supports more then one major version line of `redis-py`, then the supported python versions must include the set of supported python versions by all major version lines.
 
 - 2.7
+- 3.5
 - 3.6
 - 3.7
 - 3.8

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -6,7 +6,7 @@ This document describes what must be done when upgrading between different versi
 2.0.0 --> 2.1.0
 ---------------
 
-Python3 version must now be one of 3.6, 3.7, 3.8
+Python3 version must now be one of 3.5, 3.6, 3.7, 3.8
 
 
 1.3.x --> 2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py38, hi27, hi36, hi37, hi38, flake8-py34, flake8-py27
+envlist = py27, py35, py36, py37, py38, hi27, hi35, hi36, hi37, hi38, flake8-py34, flake8-py27
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt
@@ -12,6 +12,12 @@ commands = python {envbindir}/coverage run --source rediscluster -p -m py.test
 
 [testenv:hi27]
 basepython = python2.7
+deps =
+    -r{toxinidir}/dev-requirements.txt
+    hiredis == 0.2.0
+
+[testenv:hi35]
+basepython = python3.5
 deps =
     -r{toxinidir}/dev-requirements.txt
     hiredis == 0.2.0


### PR DESCRIPTION
Related to issue #356 https://github.com/Grokzen/redis-py-cluster/issues/356
This PR brings back support for python 3.5. 