### PR TITLE
Add username field to nodemanager

### DIFF
--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -111,6 +111,7 @@ class NodeManager(object):
             'host',
             'port',
             'db',
+            'username',
             'password',
             'socket_timeout',
             'socket_connect_timeout',


### PR DESCRIPTION
Connecting to redis 6 using ACL requires the `username` field to be passed to the core redis connection object. 

You get the following exception otherwise:
```
Traceback (most recent call last):
  File "/home/gnanesh_r/work/redisinsight/.venv/lib/python3.6/site-packages/rediscluster/nodemanager.py", line 163, in initialize
    cluster_slots = r.execute_command("cluster", "slots")
  File "/home/gnanesh_r/work/redisinsight/.venv/lib/python3.6/site-packages/redis/client.py", line 875, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File "/home/gnanesh_r/work/redisinsight/.venv/lib/python3.6/site-packages/redis/connection.py", line 1185, in get_connection
    connection.connect()
  File "/home/gnanesh_r/work/redisinsight/.venv/lib/python3.6/site-packages/redis/connection.py", line 561, in connect
    self.on_connect()
  File "/home/gnanesh_r/work/redisinsight/.venv/lib/python3.6/site-packages/redis/connection.py", line 637, in on_connect
    auth_response = self.read_response()
  File "/home/gnanesh_r/work/redisinsight/.venv/lib/python3.6/site-packages/redis/connection.py", line 752, in read_response
    raise response
redis.exceptions.ResponseError: AUTH <password> called without any password configured for the default user. Are you sure your configuration is correc
t?
```