### PR TITLE
Remove Token class checking when use XREADGROUP/XREAD

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -464,8 +464,8 @@ class RedisCluster(Redis):
             return slots.pop()
 
         if command in ['XREADGROUP', 'XREAD']:
-            tokens = {args[i].value: i for i in range(len(args)) if type(args[i]) == Token}
-            keys_ids = list(args[tokens['STREAMS'] + 1: ])
+            stream_idx = args.index(b'STREAMS')
+            keys_ids = list(args[stream_idx + 1: ])
             idx_split = len(keys_ids) // 2
             keys = keys_ids[: idx_split]
             slots = {self.connection_pool.nodes.keyslot(key) for key in keys}


### PR DESCRIPTION
redis.connection.Token  was removed from client.py but Token symbol still exists in __determins_slot_ if we use XREAD/XREADGROUP, which cause error when using XREAD/ XREADGROUP 

```
Traceback (most recent call last):
  File "stream-consumer.py", line 16, in <module>
    'stream' : '>'}
  File "/usr/local/lib/python3.6/dist-packages/redis/client.py", line 2607, in xreadgroup
    return self.execute_command('XREADGROUP', *pieces)
  File "/usr/local/lib/python3.6/dist-packages/rediscluster/client.py", line 529, in execute_command
    return self._execute_command(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/rediscluster/client.py", line 561, in _execute_command
    slot = self._determine_slot(*args)
  File "/usr/local/lib/python3.6/dist-packages/rediscluster/client.py", line 467, in _determine_slot
    tokens = {args[i].value: i for i in range(len(args)) if type(args[i]) == Token}
  File "/usr/local/lib/python3.6/dist-packages/rediscluster/client.py", line 467, in <dictcomp>
    tokens = {args[i].value: i for i in range(len(args)) if type(args[i]) == Token}
NameError: name 'Token' is not defined
```

So I replaced these lines with  byte string checking for index number,  instead.