### PR TITLE
Fix "propergate" instead of "propagate" typo in docs

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -12,6 +12,6 @@ To setup logging for debugging inside the client during development you can add 
 	logging.basicConfig()
 	logger = logging.getLogger('rediscluster')
 	logger.setLevel(logging.DEBUG)
-	logger.propergate = True
+	logger.propagate = True
 
 Note that this logging is not reccommended to be used inside production as it can cause a performance drain and a slowdown of your client.


### PR DESCRIPTION
Was looking through the changes since the 2.0.99 tag and noticed this typo.