### PR TITLE
3.0.0 development branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ python:
 services:
   - redis
 install:
-  - "if [[ $REDIS_VERSION == '3.0' ]]; then REDIS_VERSION=3.0 make redis-install; fi"
-  - "if [[ $REDIS_VERSION == '3.2' ]]; then REDIS_VERSION=3.2 make redis-install; fi"
-  - "if [[ $REDIS_VERSION == '4.0' ]]; then REDIS_VERSION=4.0 make redis-install; fi"
   - "if [[ $REDIS_VERSION == '5.0' ]]; then REDIS_VERSION=5.0 make redis-install; fi"
   - "if [[ $REDIS_VERSION == '6.0' ]]; then REDIS_VERSION=6.0 make redis-install; fi"
   - "if [[ $TEST_PYCODESTYLE == '1' ]]; then pip install pycodestyle; fi"
@@ -23,15 +20,6 @@ install:
   - "pip freeze | grep redis"
   - "pip freeze"
 env:
-  # Redis 3.0 & HIREDIS
-  - HIREDIS=0 REDIS_VERSION=3.0
-  - HIREDIS=1 REDIS_VERSION=3.0
-  # Redis 3.2 & HIREDIS
-  - HIREDIS=0 REDIS_VERSION=3.2
-  - HIREDIS=1 REDIS_VERSION=3.2
-  # Redis 4.0 & HIREDIS
-  - HIREDIS=0 REDIS_VERSION=4.0
-  - HIREDIS=1 REDIS_VERSION=4.0
   # Redis 5.0 & HIREDIS
   - HIREDIS=0 REDIS_VERSION=5.0
   - HIREDIS=1 REDIS_VERSION=5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 language: python
 cache: pip
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
@@ -50,8 +49,6 @@ after_success:
 jobs:
   allow_failures:
     - python: "nightly"
-    - python: 2.7
-      env: TEST_PYCODESTYLE=1
     - python: 3.6
       env: TEST_PYCODESTYLE=1
     # python 3.7 has to be specified manually in the matrix

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Small sample script that shows how to get started with RedisCluster. It can also
 >>> # Requires at least one node for cluster discovery. Multiple nodes is recommended.
 >>> startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
->>> rc = RedisCluster(startup_nodes=startup_nodes, decode_responses=True)
+>>> rc = RedisCluster(startup_nodes=startup_nodes)
 
 >>> rc.set("foo", "bar")
 True

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ support Python 2 until August 1, 2020. redis-py-cluster 3.0.x will be the next m
 version and will require Python 3.5+.
 
 
+# Supported redis-server versions
+
+This lib only tests for and aims to support redis-server 5.0 and above.
+
+In release 3.0.0 redis-server 3.0.x, 3.2.x and 4.0.x was dropped as officially supported redis-server versions.
+
+
 # Documentation
 
 All documentation can be found at https://redis-py-cluster.readthedocs.io/en/master

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This project is a port of `redis-rb-cluster` by antirez, with a lot of added fun
 The branch `master` will always contain the latest unstable/development code that has been merged from Pull Requests. Use the latest commit from master branch on your own risk, there is no guarantees of compatibility or stability of non tagged commits on the master branch. Only tagged releases on the `master` branch is considered stable for use.
 
 
-# Python 2 Compatibility Note
+# Python 2 Compatibility note
+
+As of redis-py-cluster 3.0.0 and above, python 2.7.x will not be supported or maintained.
 
 This library follows the announced change from our upstream package redis-py. Due to this,
 we will follow the same python 2.7 deprecation timeline as stated in there.

--- a/benchmarks/simple.py
+++ b/benchmarks/simple.py
@@ -81,10 +81,10 @@ if __name__ == "__main__":
 
     if not args["--nocluster"]:
         from rediscluster import RedisCluster
-        rc = RedisCluster(startup_nodes=startup_nodes, max_connections=32, socket_timeout=0.1, decode_responses=True)
+        rc = RedisCluster(startup_nodes=startup_nodes, max_connections=32, socket_timeout=0.1)
     else:
         from redis import Redis
-        rc = Redis(host=args["--host"], port=args["-p"], socket_timeout=0.1, decode_responses=True)
+        rc = Redis(host=args["--host"], port=args["-p"], socket_timeout=0.1)
     # create specified number processes
     processes = []
     single_request = int(args["-n"]) // int(args["-c"])

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -60,7 +60,6 @@ Example scripts:
 
     rc = RedisCluster(
         startup_nodes=startup_nodes,
-        decode_responses=True,
         host_port_remap=[
             {
                 'from_host': '172.18.0.2',
@@ -113,7 +112,6 @@ This feature is also useful in cases such as when one is trying to access AWS El
     rc = RedisCluster(
         startup_nodes=startup_nodes,
         host_port_remap=host_port_remap,
-        decode_responses=True,
         ssl=True,
         ssl_cert_reqs=None,
         # Needed for Elasticache Clusters

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,15 +85,16 @@ Python versions should follow the same supported python versions as specificed b
 
 If this library supports more then one major version line of `redis-py`, then the supported python versions must include the set of supported python versions by all major version lines.
 
-- 2.7
 - 3.5
 - 3.6
 - 3.7
 - 3.8
 
 
-Python 2 Compatibility Note
+Python 2 Compatibility note
 ###########################
+
+As of redis-py-cluster 3.0.0 and above, python 2.7.x will not be supported or maintained.
 
 This library follows the announced change from our upstream package redis-py. Due to this,
 we will follow the same python 2.7 deprecation timeline as stated in there.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,6 +95,7 @@ If this library supports more then one major version line of `redis-py`, then th
 - 3.8
 
 
+
 Python 2 Compatibility note
 ###########################
 
@@ -107,6 +108,15 @@ redis-py-cluster 2.1.x will be the last major version release that supports Pyth
 The 2.1.x line will continue to get bug fixes and security patches that
 support Python 2 until August 1, 2020. redis-py-cluster 3.0.x will be the next major
 version and will require Python 3.5+.
+
+
+
+Supported redis-server versions
+-------------------------------
+
+This lib only tests for and aims to support redis-server 5.0 and above.
+
+In release 3.0.0 redis-server 3.0.x, 3.2.x and 4.0.x was dropped as officially supported redis-server versions.
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Additional code examples of more advance functionality can be found in the `exam
     >>> startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
     >>> # Note: See note on Python 3 for decode_responses behaviour
-    >>> rc = RedisCluster(startup_nodes=startup_nodes, decode_responses=True)
+    >>> rc = RedisCluster(startup_nodes=startup_nodes)
 
     >>> rc.set("foo", "bar")
     True
@@ -53,7 +53,7 @@ Additional code examples of more advance functionality can be found in the `exam
 .. note:: Python 3
 
     Since Python 3 changed to Unicode strings from Python 2's ASCII, the return type of *most* commands will be binary strings,
-    unless the class is instantiated with the option ``decode_responses=True``.
+    unless the class is instantiated with the option ``decode_responses=Tru``.
 
     In this case, the responses will be Python 3 strings (Unicode).
 
@@ -62,6 +62,10 @@ Additional code examples of more advance functionality can be found in the `exam
     In Python 3, this means the responses will be of type `bytes`. In Python 2, they will be native strings (`str`).
 
     If `decode_responses` is set to True, for Python 3 responses will be `str`, for Python 2 they will be `unicode`.
+
+.. note:: Python 3
+
+    RedisCluster client class now defaults option `decode_responses=True` as redis-py-cluster 3.0.0 and above only supports python 3.5+ where this option should always be se to True.
 
 
 

--- a/docs/readonly-mode.rst
+++ b/docs/readonly-mode.rst
@@ -9,11 +9,11 @@ redis-py-cluster also implements this mode. You can access slave by passing `rea
 
     >>> from rediscluster import RedisCluster
     >>> startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
-    >>> rc = RedisCluster(startup_nodes=startup_nodes, decode_responses=True)
+    >>> rc = RedisCluster(startup_nodes=startup_nodes)
     >>> rc.set("foo16706", "bar")
     >>> rc.set("foo81", "foo")
     True
-    >>> rc_readonly = RedisCluster(startup_nodes=startup_nodes, decode_responses=True, readonly_mode=True)
+    >>> rc_readonly = RedisCluster(startup_nodes=startup_nodes, readonly_mode=True)
     >>> rc_readonly.get("foo16706")
     u'bar'
     >>> rc_readonly.get("foo81")
@@ -39,7 +39,7 @@ But this mode has some downside or limitations.
 
 .. code-block:: python
 
-    >>> rc_readonly = RedisCluster(startup_nodes=startup_nodes, decode_responses=True, readonly_mode=True)
+    >>> rc_readonly = RedisCluster(startup_nodes=startup_nodes, readonly_mode=True)
     >>> # NO: This works in almost case, but possibly emits Too many Cluster redirections error...
     >>> rc_readonly.set('foo', 'bar')
     >>> # OK: You should always use get related stuff...

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,6 +6,7 @@ Release Notes
 
     * Removed support for python 2.7 following the updated support level of redis-py 4.0.0 release.
     * RedisCluster client class now default "decode_responses=True" as that was always needed anyway in python 3.5+
+    * Redis-server version ranges 3.0.x, 3.2.x & 4.0.x was dropped as officially supported. Redis-server version 5.0 and above is now recommended to use in a cluster and with this client.
 
 
 2.1.0 (September 26, 2020)

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -5,6 +5,7 @@ Release Notes
 --------------------
 
     * Removed support for python 2.7 following the updated support level of redis-py 4.0.0 release.
+    * RedisCluster client class now default "decode_responses=True" as that was always needed anyway in python 3.5+
 
 
 2.1.0 (September 26, 2020)

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,8 +1,14 @@
 Release Notes
 =============
 
-2.1.0 (May **, 2020)
+3.0.0 (xxx yy, 2020)
 --------------------
+
+    * Removed support for python 2.7 following the updated support level of redis-py 4.0.0 release.
+
+
+2.1.0 (September 26, 2020)
+--------------------------
 
     * Add new config option for Client and Pipeline classes to controll how many attempts will be made before bailing out from a ClusterDownError.
       Use "cluster_down_retry_attempts=<int>" when creating the client class to controll this behaviour.

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -10,6 +10,8 @@ If you are running on pythoon 2.7 then you will not be guaranteed that this lib 
 
 If you for any reason need to set `decode_responses=False` then you need to set that explicitly now as the default value was changed to `True`.
 
+If you are using redis-server 3.0.x, 3.2.x or 4.0.x then you should upgrade to at least redis-server 5.0 or above/latest release. This client might work for older releases, but there will be no testing or validation or guarantes that it will work in the future.
+
 
 2.0.0 --> 2.1.0
 ---------------

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -3,6 +3,14 @@ Upgrading redis-py-cluster
 
 This document describes what must be done when upgrading between different versions to ensure that code still works.
 
+2.1.0 --> 3.0.0
+---------------
+
+If you are running on pythoon 2.7 then you will not be guaranteed that this lib works in that version. You should upgrade your pythoon version to 3.5+ in order for this lib and redis-py to continue to function properly.
+
+If you for any reason need to set `decode_responses=False` then you need to set that explicitly now as the default value was changed to `True`.
+
+
 2.0.0 --> 2.1.0
 ---------------
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -3,7 +3,7 @@ from rediscluster import RedisCluster
 startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
 # Note: decode_responses must be set to True when used with python3
-rc = RedisCluster(startup_nodes=startup_nodes, decode_responses=True)
+rc = RedisCluster(startup_nodes=startup_nodes)
 
 rc.set("foo", "bar")
 

--- a/examples/basic_elasticache_password_protected.py
+++ b/examples/basic_elasticache_password_protected.py
@@ -5,7 +5,6 @@ rc = RedisCluster(
     port=6379,
     password='password_is_protected',
     skip_full_coverage_check=True,  # Bypass Redis CONFIG call to elasticache 
-    decode_responses=True,          # decode_responses must be set to True when used with python3
     ssl=True,                       # in-transit encryption, https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html 
     ssl_cert_reqs=None              # see https://github.com/andymccurdy/redis-py#ssl-connections
 )

--- a/examples/basic_password_protected.py
+++ b/examples/basic_password_protected.py
@@ -3,7 +3,7 @@ from rediscluster import RedisCluster
 startup_nodes = [{"host": "127.0.0.1", "port": "7100"}]
 
 # Note: decode_responses must be set to True when used with python3
-rc = RedisCluster(startup_nodes=startup_nodes, decode_responses=True, password='password_is_protected')
+rc = RedisCluster(startup_nodes=startup_nodes, password='password_is_protected')
 
 rc.set("foo", "bar")
 

--- a/examples/generate_slot_keys.py
+++ b/examples/generate_slot_keys.py
@@ -6,7 +6,7 @@ from rediscluster import RedisCluster
 startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
 # Note: decode_responses must be set to True when used with python3
-rc = RedisCluster(startup_nodes=startup_nodes, decode_responses=True)
+rc = RedisCluster(startup_nodes=startup_nodes)
 
 # 10 batches
 batch_set = {i: [] for i in range(0, 16384)}

--- a/examples/incr-test-writer.py
+++ b/examples/incr-test-writer.py
@@ -2,7 +2,7 @@ from redis._compat import xrange
 from rediscluster import RedisCluster
 
 startup_nodes = [{"host": "127.0.0.1", "port": 7000}]
-r = RedisCluster(startup_nodes=startup_nodes, max_connections=32, decode_responses=True)
+r = RedisCluster(startup_nodes=startup_nodes, max_connections=32)
 
 for i in xrange(1000000):
     d = str(i)

--- a/examples/pipeline-incrby.py
+++ b/examples/pipeline-incrby.py
@@ -2,7 +2,7 @@ from redis._compat import xrange
 from rediscluster import RedisCluster
 
 startup_nodes = [{"host": "127.0.0.1", "port": 7000}]
-r = RedisCluster(startup_nodes=startup_nodes, max_connections=32, decode_responses=True)
+r = RedisCluster(startup_nodes=startup_nodes, max_connections=32)
 
 for i in xrange(1000000):
     d = str(i)

--- a/ptp-debug.py
+++ b/ptp-debug.py
@@ -3,7 +3,7 @@ from rediscluster import RedisCluster
 startup_nodes = [{"host": "127.0.0.1", "port": "7000"}]
 
 # Note: decode_responses must be set to True when used with python3
-rc = RedisCluster(startup_nodes=startup_nodes, decode_responses=True)
+rc = RedisCluster(startup_nodes=startup_nodes)
 url_client = RedisCluster.from_url('http://127.0.0.1:7000')
 
 __import__('ptpdb').set_trace()

--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -302,7 +302,8 @@ class RedisCluster(Redis):
 
     def __init__(self, host=None, port=None, startup_nodes=None, max_connections=None, max_connections_per_node=False, init_slot_cache=True,
                  readonly_mode=False, reinitialize_steps=None, skip_full_coverage_check=False, nodemanager_follow_cluster=False,
-                 connection_class=None, read_from_replicas=False, cluster_down_retry_attempts=3, host_port_remap=None, **kwargs):
+                 connection_class=None, read_from_replicas=False, cluster_down_retry_attempts=3, host_port_remap=None, decode_responses=True,
+                 **kwargs):
         """
         :startup_nodes:
             List of nodes that initial bootstrapping can be done from
@@ -372,6 +373,7 @@ class RedisCluster(Redis):
                 nodemanager_follow_cluster=nodemanager_follow_cluster,
                 connection_class=connection_class,
                 host_port_remap=host_port_remap,
+                decode_responses=decode_responses,
                 **kwargs
             )
 

--- a/rediscluster/crc.py
+++ b/rediscluster/crc.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-# python std lib
-import sys
-
 x_mode_m_crc16_lookup = [
     0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
     0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,
@@ -39,25 +36,10 @@ x_mode_m_crc16_lookup = [
 ]
 
 
-def _crc16_py3(data):
+def crc16(data):
     """
     """
     crc = 0
     for byte in data:
         crc = ((crc << 8) & 0xff00) ^ x_mode_m_crc16_lookup[((crc >> 8) & 0xff) ^ byte]
     return crc & 0xffff
-
-
-def _crc16_py2(data):
-    """
-    """
-    crc = 0
-    for byte in data:
-        crc = ((crc << 8) & 0xff00) ^ x_mode_m_crc16_lookup[((crc >> 8) & 0xff) ^ ord(byte)]
-    return crc & 0xffff
-
-
-if sys.version_info >= (3, 0, 0):
-    crc16 = _crc16_py3
-else:
-    crc16 = _crc16_py2

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -99,7 +99,6 @@ class NodeManager(object):
     def keyslot(self, key):
         """
         Calculate keyslot for a given key.
-        Tuned for compatibility with python 2.7.x
         """
         k = self.encoder.encode(key)
 

--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -48,7 +48,7 @@ class NodeManager(object):
         self.encoder = Encoder(
             connection_kwargs.get('encoding', 'utf-8'),
             connection_kwargs.get('encoding_errors', 'strict'),
-            connection_kwargs.get('decode_responses', False)
+            connection_kwargs.get('decode_responses', True),
         )
         self._validate_host_port_remap(host_port_remap)
         self.host_port_remap = host_port_remap
@@ -152,7 +152,7 @@ class NodeManager(object):
 
         return self.nodes[key]
 
-    def get_redis_link(self, host, port, decode_responses=False):
+    def get_redis_link(self, host, port, decode_responses=True):
         """
         """
         allowed_keys = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-redis>=3.0.0,<4.0.0
+# Pin this to the latest released version for now. Should use development branch of redis-py in reality but will do for now
+redis>=3.5.3

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,10 @@ setup(
     install_requires=[
         'redis>=3.5.3'
     ],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4",
+    python_requires=">=3.5",
     extras_require={
         'hiredis': [
-            "hiredis>=0.1.3",
+            "hiredis>=0.2.0",
         ],
     },
     keywords=[
@@ -54,8 +54,6 @@ setup(
         # 'Development Status :: 6 - Mature',
         # 'Development Status :: 7 - Inactive',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     url='http://github.com/grokzen/redis-py-cluster',
     license='MIT',
     install_requires=[
-        'redis>=3.0.0,<4.0.0'
+        'redis>=3.5.3'
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4",
     extras_require={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,7 +150,7 @@ def o(request, *args, **kwargs):
     """
     Create a RedisCluster instance with decode_responses set to True.
     """
-    return _init_client(request, cls=RedisCluster, decode_responses=True, **kwargs)
+    return _init_client(request, cls=RedisCluster, **kwargs)
 
 
 @pytest.fixture()

--- a/tests/test_cluster_node_manager.py
+++ b/tests/test_cluster_node_manager.py
@@ -227,7 +227,6 @@ def test_init_slots_cache_slots_collision():
         r = RedisCluster(
             host=host,
             port=port,
-            decode_responses=True,
             skip_full_coverage_check=False,
         )
 
@@ -431,7 +430,7 @@ def test_init_with_down_node():
     If I can't connect to one of the nodes, everything should still work.
     But if I can't connect to any of the nodes, exception should be thrown.
     """
-    def get_redis_link(host, port, decode_responses=False):
+    def get_redis_link(host, port, decode_responses=True):
         if port == 7000:
             raise ConnectionError('mock connection error for 7000')
         return Redis(host=host, port=port, decode_responses=decode_responses)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -17,7 +17,7 @@ class TestEncoding(object):
         return _get_client(
             redis.Redis,
             request=request,
-            decode_responses=False,
+            decode_responses=True,
         )
 
     @pytest.mark.skip(reason="Cluster specific override")

--- a/tests/test_encoding_cluster.py
+++ b/tests/test_encoding_cluster.py
@@ -17,14 +17,13 @@ class TestEncodingCluster(object):
     """
     @pytest.fixture()
     def r(self, request):
-        return _get_client(RedisCluster, request=request, decode_responses=True)
+        return _get_client(RedisCluster, request=request)
 
     @pytest.fixture()
     def r_no_decode(self, request):
         return _get_client(
             RedisCluster,
             request=request,
-            decode_responses=False,
         )
 
     def test_simple_encoding(self, r_no_decode):
@@ -67,13 +66,11 @@ class TestEncodingCluster(object):
 
 class TestEncodingErrors(object):
     def test_ignore(self, request):
-        r = _get_client(RedisCluster, request=request, decode_responses=True,
-                        encoding_errors='ignore')
+        r = _get_client(RedisCluster, request=request, encoding_errors='ignore')
         r.set('a', b'foo\xff')
         assert r.get('a') == 'foo'
 
     def test_replace(self, request):
-        r = _get_client(RedisCluster, request=request, decode_responses=True,
-                        encoding_errors='replace')
+        r = _get_client(RedisCluster, request=request, encoding_errors='replace')
         r.set('a', b'foo\xff')
         assert r.get('a') == 'foo\ufffd'

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -15,7 +15,7 @@ class TestLock(object):
         """
         Helper function modified for RedisCluster usage to make tests work
         """
-        return _get_client(RedisCluster, request=request, decode_responses=True)
+        return _get_client(RedisCluster, request=request)
 
     def get_lock(self, redis, *args, **kwargs):
         kwargs['lock_class'] = Lock

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -491,7 +491,6 @@ def test_pubsub_thread_publish():
 
     r = RedisCluster(
         startup_nodes=startup_nodes,
-        decode_responses=True,
         max_connections=16,
         max_connections_per_node=16,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,11 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, py37, py38, hi27, hi35, hi36, hi37, hi38, flake8-py34, flake8-py27
+envlist = py35, py36, py37, py38, hi35, hi36, hi37, hi38, flake8-py36
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt
 commands = python {envbindir}/coverage run --source rediscluster -p -m py.test
-
-[testenv:hi27]
-basepython = python2.7
-deps =
-    -r{toxinidir}/dev-requirements.txt
-    hiredis == 0.2.0
 
 [testenv:hi35]
 basepython = python3.5
@@ -42,12 +36,6 @@ deps =
 
 [testenv:flake8-py36]
 basepython= python3.6
-deps =
-    flake8==3.7.9
-commands = flake8 --show-source --exclude=.venv,.tox,dist,docs,build,.git --ignore=E501,E731,E402 .
-
-[testenv:flake8-py27]
-basepython= python2.7
 deps =
     flake8==3.7.9
 commands = flake8 --show-source --exclude=.venv,.tox,dist,docs,build,.git --ignore=E501,E731,E402 .


### PR DESCRIPTION
Development branch for the next major release 3.0.0.

This time around the release will be as much complete as possible so when redis-py version 4.0.0 drops this lib can release at the same time.

Any issue with the `3.0.0` label will be attempted to be included in this branch before finishing this work.