### PR TITLE
only send readonly to replicas once on new connections

### DIFF
--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -343,6 +343,10 @@ class ClusterConnectionPool(ConnectionPool):
             connection = self._available_connections.get(node["name"], []).pop()
         except IndexError:
             connection = self.make_connection(node)
+            if node["server_type"] == "slave":
+                connection.send_command('READONLY')
+                if nativestr(connection.read_response()) != 'OK':
+                    raise ConnectionError('READONLY command failed')
 
         self._in_use_connections.setdefault(node["name"], set()).add(connection)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5668429/95126186-0d66f380-0724-11eb-949f-11870ab1afa3.png)

replicas have more CPU load because of extra commands(2x) than masters.