### PR TITLE
Reduce log level of ClusterConnection creation

### DIFF
--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -45,7 +45,7 @@ class ClusterConnection(Connection):
     "Manages TCP communication to and from a Redis server"
 
     def __init__(self, *args, **kwargs):
-        log.info("Createing new ClusterConnection instance")
+        log.debug("Creating new ClusterConnection instance")
         log.debug(str(args) + " : " + str(kwargs))
 
         self.readonly = kwargs.pop('readonly', False)


### PR DESCRIPTION
Hi! Thanks for setting up all the logging, it's been very helpful.

Would you be up for reducing the log level here? We've found that it's spewing a ton of logs for us. For the time being we've just reduced our output via `logging.getLogger("rediscluster.connection").setLevel(logging.WARN)` but we'd like to keep some of the other info-level logs around. 