### PR TITLE
Fix "RedisCluster object has no attribute connection" error

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -362,6 +362,11 @@ class RedisCluster(Redis):
 
             log.debug("Connection pool class " + str(connection_pool_cls))
 
+            # If connection pool fails to initialize, parent class (Redis) __del__
+            # will try to access self.connection before it's defined
+            # throwing an AttributeError.
+            self.connection = None
+
             pool = connection_pool_cls(
                 startup_nodes=startup_nodes,
                 init_slot_cache=init_slot_cache,


### PR DESCRIPTION
#433 

Comment explains why this seems necessary.

`RedisCluster` class assumes that initialization errors are not recoverable. It throws the exception in the constructor before calling its parent class constructor, causing its parent class `__del__` encounter an undefined attribute on clean up.

This change allows for the parent class to cleanly shutdown so the calling code can try again.