### PR TITLE
Export ClusterPipeline as part of rediscluster

### DIFF
--- a/rediscluster/__init__.py
+++ b/rediscluster/__init__.py
@@ -23,6 +23,7 @@ from rediscluster.exceptions import (
     MovedError,
     MasterDownError,
 )
+from rediscluster.pipeline import ClusterPipeline
 
 
 def int_or_str(value):
@@ -45,6 +46,7 @@ __all__ = [
     ClusterDownError,
     ClusterDownException,
     ClusterError,
+    ClusterPipeline,
     MasterDownError,
     MovedError,
     RedisCluster,


### PR DESCRIPTION
This will allow users of the library to subclass `ClusterPipeline` as well as `RedisClient`



Fixes https://github.com/Grokzen/redis-py-cluster/issues/441