### PR TITLE
Support reading from replicas on pipeline executions

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -53,6 +53,50 @@ from redis.exceptions import (
     TimeoutError,
 )
 
+# Not complete, but covers the major ones
+# https://redis.io/commands
+READ_COMMANDS = frozenset([
+    "BITCOUNT",
+    "BITPOS",
+    "EXISTS",
+    "GEODIST",
+    "GEOHASH",
+    "GEOPOS",
+    "GEORADIUS",
+    "GEORADIUSBYMEMBER",
+    "GET",
+    "GETBIT",
+    "GETRANGE",
+    "HEXISTS",
+    "HGET",
+    "HGETALL",
+    "HKEYS",
+    "HLEN",
+    "HMGET",
+    "HSTRLEN",
+    "HVALS",
+    "KEYS",
+    "LINDEX",
+    "LLEN",
+    "LRANGE",
+    "MGET",
+    "PTTL",
+    "RANDOMKEY",
+    "SCARD",
+    "SDIFF",
+    "SINTER",
+    "SISMEMBER",
+    "SMEMBERS",
+    "SRANDMEMBER",
+    "STRLEN",
+    "SUNION",
+    "TTL",
+    "ZCARD",
+    "ZCOUNT",
+    "ZRANGE",
+    "ZSCORE",
+])
+
 
 log = logging.getLogger(__name__)
 
@@ -167,50 +211,6 @@ class RedisCluster(Redis):
             "CLUSTER GETKEYSINSLOT",
         ], 'slot-id'),
     )
-
-    # Not complete, but covers the major ones
-    # https://redis.io/commands
-    READ_COMMANDS = [
-        "BITCOUNT",
-        "BITPOS",
-        "EXISTS",
-        "GEODIST",
-        "GEOHASH",
-        "GEOPOS",
-        "GEORADIUS",
-        "GEORADIUSBYMEMBER",
-        "GET",
-        "GETBIT",
-        "GETRANGE",
-        "HEXISTS",
-        "HGET",
-        "HGETALL",
-        "HKEYS",
-        "HLEN",
-        "HMGET",
-        "HSTRLEN",
-        "HVALS",
-        "KEYS",
-        "LINDEX",
-        "LLEN",
-        "LRANGE",
-        "MGET",
-        "PTTL",
-        "RANDOMKEY",
-        "SCARD",
-        "SDIFF",
-        "SINTER",
-        "SISMEMBER",
-        "SMEMBERS",
-        "SRANDMEMBER",
-        "STRLEN",
-        "SUNION",
-        "TTL",
-        "ZCARD",
-        "ZCOUNT",
-        "ZRANGE",
-        "ZSCORE",
-    ]
 
     RESULT_CALLBACKS = dict_merge(
         string_keys_to_dict([
@@ -608,7 +608,7 @@ class RedisCluster(Redis):
                     else:
                         node = self.connection_pool.get_node_by_slot(
                             slot,
-                            self.read_from_replicas and (command in self.READ_COMMANDS)
+                            self.read_from_replicas and (command in READ_COMMANDS)
                         )
                         is_read_replica = node['server_type'] == 'slave'
 

--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -4,7 +4,7 @@
 import sys
 
 # rediscluster imports
-from .client import RedisCluster
+from .client import RedisCluster, READ_COMMANDS
 from .exceptions import (
     RedisClusterException, AskError, MovedError, TryAgainError, ClusterDownError,
 )
@@ -194,7 +194,7 @@ class ClusterPipeline(RedisCluster):
             # refer to our internal node -> slot table that tells us where a given
             # command should route to.
             slot = self._determine_slot(*c.args)
-            node = self.connection_pool.get_node_by_slot(slot)
+            node = self.connection_pool.get_node_by_slot(slot, self.read_from_replicas and c.args[0] in READ_COMMANDS)
 
             # little hack to make sure the node name is populated. probably could clean this up.
             self.connection_pool.nodes.set_node_name(node)


### PR DESCRIPTION
This is the smallest possible change that should still satisfy https://github.com/Grokzen/redis-py-cluster/issues/400 

I've been testing it with our own client code and it seems to work as expected.

Something to note about this implementation is that it won't necessarily stick to the same replica for all read operations within the same shard. There are two reasons for this:
* changing this behaviour would complicate the implementation and probably require making the connection pools pipeline-aware somehow as well, or provide a custom connection pool for this use case.
* I actually think the behaviour as implemented is preferable as it will distribute the load across replicas, which is the original goal of this change anyway.