### PR TITLE
Do not attempt to disconnect if connection is none

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -647,7 +647,11 @@ class RedisCluster(Redis):
             except ConnectionError:
                 log.exception("ConnectionError")
 
-                connection.disconnect()
+                # ConnectionError can also be raised if we couldn't get a connection
+                # from the pool before timing out, so check that this is an actual
+                # connection before attempting to disconnect.
+                if connection is not None:
+                    connection.disconnect()
                 connection_error_retry_counter += 1
 
                 # Give the node 0.1 seconds to get back up and retry again with same


### PR DESCRIPTION
When handling a ConnectionError we could be faced with the situation
that we still don't have a connection, so attempting to disconnect would
result in an error. To prevent this, we first check if the connection is
None before attempting to disconnect.

Fixes https://github.com/Grokzen/redis-py-cluster/issues/453