### PR TITLE
Fix reading from replicas in pipelined commands

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -582,7 +582,6 @@ class RedisCluster(Redis):
 
         redirect_addr = None
         asking = False
-        is_read_replica = False
 
         try_random_node = False
         slot = self._determine_slot(*args)
@@ -610,7 +609,6 @@ class RedisCluster(Redis):
                             slot,
                             self.read_from_replicas and (command in READ_COMMANDS)
                         )
-                        is_read_replica = node['server_type'] == 'slave'
 
                     connection = self.connection_pool.get_connection_by_node(node)
 
@@ -620,12 +618,6 @@ class RedisCluster(Redis):
                     connection.send_command('ASKING')
                     self.parse_response(connection, "ASKING", **kwargs)
                     asking = False
-                if is_read_replica:
-                    # Ask read replica to accept reads (see https://redis.io/commands/readonly)
-                    # TODO: do we need to handle errors from this response?
-                    connection.send_command('READONLY')
-                    self.parse_response(connection, 'READONLY', **kwargs)
-                    is_read_replica = False
 
                 connection.send_command(*args)
                 return self.parse_response(connection, command, **kwargs)

--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -270,7 +270,8 @@ class ClusterConnectionPool(ConnectionPool):
 
         self._created_connections_per_node.setdefault(node['name'], 0)
         self._created_connections_per_node[node['name']] += 1
-        connection = self.connection_class(host=node["host"], port=node["port"], **self.connection_kwargs)
+        readonly = node["server_type"] == "slave"
+        connection = self.connection_class(host=node["host"], port=node["port"], readonly=readonly, **self.connection_kwargs)
 
         # Must store node in the connection to make it easier to track
         connection.node = node
@@ -472,7 +473,8 @@ class ClusterBlockingConnectionPool(ClusterConnectionPool):
 
     def make_connection(self, node):
         """ Create a new connection """
-        connection = self.connection_class(host=node["host"], port=node["port"], **self.connection_kwargs)
+        readonly = node["server_type"] == "slave"
+        connection = self.connection_class(host=node["host"], port=node["port"], readonly=readonly, **self.connection_kwargs)
         self._connections.append(connection)
         connection.node = node
         return connection


### PR DESCRIPTION
We fail to send the `READONLY` command to replicas when running commands inside a pipeline, which results in an increased latency as the server will respond with an unneeded `MOVED` message forcing us to retry the command.

We move the sending of the `READONLY` command to the connection creation itself, since at that point we already know if we're connecting to a replica or not, so we can ensure consistency on sending this command.

Fixes https://github.com/Grokzen/redis-py-cluster/issues/470